### PR TITLE
Stage 1: Intent-MPC dataflow analysis

### DIFF
--- a/docs/project_management/github_workflow.md
+++ b/docs/project_management/github_workflow.md
@@ -1,0 +1,80 @@
+# GitHub Project Workflow
+
+This repository is managed as a staged research project for:
+
+> 基于多模态感知不确定性的无人机动态障碍物安全避障方法研究
+
+The `main` branch currently stores the high-level research plan. The reproduction and code-reading branches keep the executable Intent-MPC codebase and stage-specific documentation.
+
+## Branch Policy
+
+- `main`: stable project overview, roadmap, and accepted stage summaries.
+- `stage0-reproduction-stability`: stage 0 reproduction, Docker/ROS Noetic environment, runtime stability fixes, and validation report.
+- `stage1-code-reading-baseline`: stage 1 code-reading branch for Intent-MPC data flow, ROS interfaces, and algorithm insertion-point analysis.
+- Future branches:
+  - `stage2-experiment-logging`
+  - `stage3-perception-degradation`
+  - `stage4-multimodal-uncertainty`
+  - `stage5-safety-local-planner`
+  - `stage6-paper-experiment-matrix`
+  - `stage7-paper-materials`
+
+Each stage should end with:
+
+- A stage report under `docs/stageX/`.
+- A clear validation checklist.
+- A pull request description covering goal, changed files, commands, result, and remaining risks.
+
+## GitHub Milestones
+
+Created milestones:
+
+- `Stage 0 - Reproduction`
+- `Stage 1 - Intent-MPC Data Flow`
+- `Stage 2 - Experiment Logging`
+- `Stage 3 - Perception Degradation`
+- `Stage 4 - Multimodal Uncertainty`
+- `Stage 5 - Safety Local Planner`
+- `Stage 6 - Paper Experiment Matrix`
+- `Stage 7 - Paper Materials`
+
+`Stage 0 - Reproduction` is closed because the official demo was reproduced and validated on this machine.
+
+## GitHub Issues
+
+Created tracking issues:
+
+- [#1 Stage 0 accepted: Intent-MPC reproduction environment and report](https://github.com/zsz15964443357-lab/UAV/issues/1)
+- [#2 Stage 1: map launch tree, ROS nodes, topics, and TF interfaces](https://github.com/zsz15964443357-lab/UAV/issues/2)
+- [#3 Stage 1: trace dynamic obstacle generation and message formats](https://github.com/zsz15964443357-lab/UAV/issues/3)
+- [#4 Stage 1: analyze dynamic_predictor inputs, outputs, and assumptions](https://github.com/zsz15964443357-lab/UAV/issues/4)
+- [#5 Stage 1: inspect trajectory_planner/time_optimizer dynamic obstacle handling](https://github.com/zsz15964443357-lab/UAV/issues/5)
+- [#6 Stage 1: produce insertion-point design for uncertainty-aware planning](https://github.com/zsz15964443357-lab/UAV/issues/6)
+- [#7 Stage 2: define experiment CSV schema and run metadata](https://github.com/zsz15964443357-lab/UAV/issues/7)
+- [#8 Stage 2: implement baseline metric recorder and statistics scripts](https://github.com/zsz15964443357-lab/UAV/issues/8)
+- [#9 Stage 3: design perception_degradation_node interface](https://github.com/zsz15964443357-lab/UAV/issues/9)
+- [#10 Stage 3: implement configurable perception degradation module](https://github.com/zsz15964443357-lab/UAV/issues/10)
+- [#11 Stage 4: define uncertainty obstacle schema and effective radius formula](https://github.com/zsz15964443357-lab/UAV/issues/11)
+- [#12 Stage 4: visualize uncertainty and risk radius in RViz](https://github.com/zsz15964443357-lab/UAV/issues/12)
+- [#13 Stage 5: add fixed safety margin baseline](https://github.com/zsz15964443357-lab/UAV/issues/13)
+- [#14 Stage 5: add uncertainty-aware radius inflation and risk cost](https://github.com/zsz15964443357-lab/UAV/issues/14)
+- [#15 Stage 6: define scenario, degradation, seed, and method matrix](https://github.com/zsz15964443357-lab/UAV/issues/15)
+- [#16 Stage 6: generate paper tables and robustness curves](https://github.com/zsz15964443357-lab/UAV/issues/16)
+- [#17 Stage 7: organize diagrams, paper outline, and failure analysis](https://github.com/zsz15964443357-lab/UAV/issues/17)
+- [#18 Management: reconcile README-only main with reproduction branches](https://github.com/zsz15964443357-lab/UAV/issues/18)
+
+## Main Branch Risk
+
+Current state:
+
+- `uav/main` contains the research roadmap README only.
+- `stage0-reproduction-stability` contains the full Intent-MPC codebase and reproduction changes.
+- These two histories currently have no common merge base.
+
+Before merging stage work into `main`, decide how to reconcile this:
+
+1. Keep `main` as the project homepage and merge the full code through PR, resolving README conflicts.
+2. Update `main` to the full codebase plus the project roadmap.
+
+This is tracked in [#18](https://github.com/zsz15964443357-lab/UAV/issues/18).
+

--- a/docs/stage1/README.md
+++ b/docs/stage1/README.md
@@ -1,0 +1,50 @@
+# Stage 1: Intent-MPC Data Flow
+
+Goal: identify where dynamic obstacle state is generated, predicted, passed into MPC, and constrained, so later uncertainty-aware planning can be added with minimal algorithm disruption.
+
+This stage is analysis-only. Do not modify planner behavior in this branch unless a separate issue explicitly says so.
+
+## Source Plan
+
+The overall roadmap was read from `uav/main:README.md`. Stage 1 focuses on:
+
+- Dynamic obstacle state generation.
+- `dynamic_predictor` inputs and outputs.
+- `trajectory_planner` / `time_optimizer` obstacle costs or constraints.
+- Planner obstacle message/data format.
+- Insertion point for `obstacle_state -> uncertainty_obstacle_state -> planner`.
+
+## GitHub Tracking
+
+Milestone: [Stage 1 - Intent-MPC Data Flow](https://github.com/zsz15964443357-lab/UAV/milestone/2)
+
+Primary issues:
+
+- [#2 Launch tree, ROS nodes, topics, and TF interfaces](https://github.com/zsz15964443357-lab/UAV/issues/2)
+- [#3 Dynamic obstacle generation and message formats](https://github.com/zsz15964443357-lab/UAV/issues/3)
+- [#4 `dynamic_predictor` inputs, outputs, and assumptions](https://github.com/zsz15964443357-lab/UAV/issues/4)
+- [#5 `trajectory_planner` / `time_optimizer` dynamic obstacle handling](https://github.com/zsz15964443357-lab/UAV/issues/5)
+- [#6 Insertion-point design](https://github.com/zsz15964443357-lab/UAV/issues/6)
+
+## Current Branch
+
+Branch: `stage1-code-reading-baseline`
+
+Base: `stage0-reproduction-stability`
+
+Reason: stage 0 already contains the working Docker/ROS Noetic reproduction environment and runtime stability fixes. Starting stage 1 from it preserves the runnable baseline.
+
+## Initial Artifacts
+
+- [`initial_dataflow_map.md`](initial_dataflow_map.md): first-pass map of launch files, modules, topics, data structures, and insertion-point candidates.
+
+## Acceptance Checklist
+
+- [ ] Launch tree and runtime node graph documented.
+- [ ] UAV pose/velocity/control/planning topics documented.
+- [ ] Dynamic obstacle generation path documented.
+- [ ] `dynamic_predictor` input/output format documented.
+- [ ] MPC dynamic obstacle constraint path documented.
+- [ ] Candidate uncertainty insertion points ranked.
+- [ ] Stage 1 final report completed.
+

--- a/docs/stage1/README.md
+++ b/docs/stage1/README.md
@@ -37,14 +37,18 @@ Reason: stage 0 already contains the working Docker/ROS Noetic reproduction envi
 ## Initial Artifacts
 
 - [`initial_dataflow_map.md`](initial_dataflow_map.md): first-pass map of launch files, modules, topics, data structures, and insertion-point candidates.
+- [`stage1_execution_prompt.md`](stage1_execution_prompt.md): reusable prompt for reproducing or extending Stage 1 analysis.
+- [`stage1_final_report.md`](stage1_final_report.md): final Stage 1 dataflow report with file/function evidence.
+- [`insertion_point_design.md`](insertion_point_design.md): ranked uncertainty-aware planning insertion-point design.
 
 ## Acceptance Checklist
 
-- [ ] Launch tree and runtime node graph documented.
-- [ ] UAV pose/velocity/control/planning topics documented.
-- [ ] Dynamic obstacle generation path documented.
-- [ ] `dynamic_predictor` input/output format documented.
-- [ ] MPC dynamic obstacle constraint path documented.
-- [ ] Candidate uncertainty insertion points ranked.
-- [ ] Stage 1 final report completed.
+- [x] Launch tree and runtime node graph documented.
+- [x] UAV pose/velocity/control/planning topics documented.
+- [x] Dynamic obstacle generation path documented.
+- [x] `dynamic_predictor` input/output format documented.
+- [x] MPC dynamic obstacle constraint path documented.
+- [x] Candidate uncertainty insertion points ranked.
+- [x] Stage 1 final report completed.
 
+Conclusion: Stage 1 acceptance criteria are met. Next recommended branch is `stage2-experiment-logging`.

--- a/docs/stage1/initial_dataflow_map.md
+++ b/docs/stage1/initial_dataflow_map.md
@@ -1,0 +1,365 @@
+# Initial Dataflow Map
+
+This is the first-pass Stage 1 map based on static code reading. It is intentionally analysis-only and does not change the algorithm.
+
+## Demo Launch Tree
+
+Official demo:
+
+```bash
+roslaunch uav_simulator start.launch
+roslaunch autonomous_flight intent_mpc_demo.launch
+```
+
+Fast visualization variant:
+
+```bash
+roslaunch uav_simulator start.launch
+roslaunch autonomous_flight intent_mpc_demo_fast_visual.launch
+```
+
+### `uav_simulator/launch/start.launch`
+
+Main responsibilities:
+
+- Starts Gazebo with `uav_simulator/worlds/generated_env/generated_env.world`.
+- Loads `uav_simulator/urdf/quadcopter.urdf` by default.
+- Spawns the UAV model as `quadcopter` at `(0.0, 7.0, 0.1)` with yaw `-3.14`.
+- Throttles raw simulator state topics to 30 Hz:
+  - `/CERLAB/quadcopter/pose_raw -> /CERLAB/quadcopter/pose`
+  - `/CERLAB/quadcopter/vel_raw -> /CERLAB/quadcopter/vel`
+  - `/CERLAB/quadcopter/acc_raw -> /CERLAB/quadcopter/acc`
+  - `/CERLAB/quadcopter/odom_raw -> /CERLAB/quadcopter/odom`
+- Includes `uav_simulator/launch/setupTF.launch`.
+- Starts `keyboard_control`.
+
+### `autonomous_flight/launch/intent_mpc_demo.launch`
+
+Loads:
+
+- `tracking_controller/cfg/controller_param.yaml` under namespace `controller`.
+- `autonomous_flight/cfg/mpc_navigation/fake_detector_param.yaml`.
+- `autonomous_flight/cfg/mpc_navigation/flight_base.yaml` under namespace `autonomous_flight`.
+- `autonomous_flight/cfg/mpc_navigation/planner_param.yaml`.
+- `autonomous_flight/cfg/mpc_navigation/mapping_param.yaml` under namespace `/dynamic_map`.
+- `autonomous_flight/cfg/mpc_navigation/dynamic_detector_param.yaml` under namespace `/onboard_detector`.
+- `autonomous_flight/cfg/mpc_navigation/predictor_param.yaml` under namespace `/dynamic_predictor`.
+
+Starts:
+
+- `tracking_controller_node`
+- `mpc_navigation_node`
+- RViz through `remote_control/launch/mpc_navigation_rviz.launch`
+
+The fast visualization variant replaces the RViz include with `remote_control/launch/mpc_navigation_fast_rviz.launch`.
+
+## Runtime Module Map
+
+### Simulation and UAV State
+
+`uav_simulator/src/quadcopterPlugin.cpp`
+
+- Publishes raw UAV state:
+  - `/CERLAB/quadcopter/pose_raw`
+  - `/CERLAB/quadcopter/vel_raw`
+  - `/CERLAB/quadcopter/acc_raw`
+  - `/CERLAB/quadcopter/odom_raw`
+- Subscribes control commands:
+  - `/CERLAB/quadcopter/cmd_acc`
+  - `/CERLAB/quadcopter/cmd_vel`
+  - `/CERLAB/quadcopter/setpoint_pose`
+
+`topic_tools/throttle` republishes raw state to the runtime state topics used by the planner and controller.
+
+### Flight Base and Navigation
+
+`autonomous_flight/src/mpc_navigation_node.cpp`
+
+- Creates `AutoFlight::mpcNavigation`.
+
+`autonomous_flight/include/autonomous_flight/flightBase.cpp`
+
+- In simulation mode, subscribes:
+  - `/CERLAB/quadcopter/odom`
+  - `/move_base_simple/goal`
+- Publishes:
+  - `/CERLAB/quadcopter/setpoint_pose`
+  - `/autonomous_flight/target_state`
+- Maintains current position, velocity, acceleration, yaw, and target state.
+
+`autonomous_flight/include/autonomous_flight/mpcNavigation.cpp`
+
+- Builds the high-level stack:
+  - `onboardDetector::fakeDetector` when `use_fake_detector: true`.
+  - `mapManager::dynamicMap`.
+  - `dynamicPredictor::predictor` when `use_predictor: true`.
+  - RRT planner.
+  - polynomial trajectory planner.
+  - MPC planner.
+- Publishes visualization paths:
+  - `mpcNavigation/rrt_path`
+  - `mpcNavigation/poly_traj`
+  - `mpcNavigation/pwl_trajectory`
+  - `mpcNavigation/mpc_trajectory`
+  - `mpcNavigation/input_trajectory`
+  - `mpcNavigation/goal`
+- Sends planned tracking targets to `/autonomous_flight/target_state`.
+
+## Dynamic Obstacle Data Path
+
+### Ground-truth simulation detector path
+
+`onboard_detector/include/onboard_detector/fakeDetector.cpp`
+
+- Subscribes `/gazebo/model_states`.
+- Selects models whose names start with configured target prefixes:
+  - `person`
+  - `dynamic_box`
+  - `dynamic_cylinder`
+- Estimates obstacle velocity and acceleration from model state differences.
+- Parses obstacle dimensions from Gazebo model names.
+- Publishes visualization:
+  - `onboard_detector/GT_obstacle_bbox`
+  - `onboard_detector/history_trajectories`
+- Provides service:
+  - `fake_detector/getDynamicObstacles`
+- Provides in-process accessors used by `mpcNavigation` and `dynamicPredictor`:
+  - `getObstacles`
+  - `getObstaclesInSensorRange`
+  - `getDynamicObstaclesHist`
+
+Core obstacle struct:
+
+```cpp
+onboardDetector::box3D {
+  double x, y, z;
+  double x_width, y_width, z_width;
+  double id;
+  double Vx, Vy, Vz;
+  double Ax, Ay, Az;
+  bool is_human;
+  bool is_dynamic;
+  bool fix_size;
+  bool is_dynamic_candidate;
+  bool is_estimated;
+}
+```
+
+### Real/perception detector path
+
+`map_manager/include/map_manager/dynamicMap.cpp`
+
+- Owns `onboardDetector::dynamicDetector`.
+- Calls `dynamicDetector::getDynamicObstacles`.
+- Converts `box3D` to:
+  - `std::vector<Eigen::Vector3d> obstaclePos`
+  - `std::vector<Eigen::Vector3d> obstacleVel`
+  - `std::vector<Eigen::Vector3d> obstacleSize`
+- Frees occupied map regions corresponding to dynamic obstacles.
+
+`onboard_detector/include/onboard_detector/dynamicDetector.cpp`
+
+- Uses depth/color/yolo inputs in the non-fake detector path.
+- Publishes:
+  - `onboard_detector/dynamic_point_cloud`
+  - `onboard_detector/dynamic_bboxes`
+- Maintains tracked dynamic bounding boxes and histories.
+
+The official demo uses fake detector mode, but the real detector path is important for later multimodal perception uncertainty work.
+
+## Predictor Data Path
+
+`dynamic_predictor/include/dynamic_predictor/dynamicPredictor.cpp`
+
+Inputs:
+
+- Fake detector history through `fakeDetector::getDynamicObstaclesHist`, when simulation fake detector is enabled.
+- Real detector history through `dynamicDetector::getDynamicObstaclesHist`, otherwise.
+
+Parameters:
+
+- `dynamic_predictor/prediction_size`
+- `dynamic_predictor/prediction_time_step`
+- `dynamic_predictor/prediction_z_score`
+- `dynamic_predictor/min_turning_time`
+- `dynamic_predictor/max_turning_time`
+- `dynamic_predictor/max_front_prob`
+- `dynamic_predictor/front_angle`
+- `dynamic_predictor/stop_velocity_thereshold`
+- `dynamic_predictor/prob_scale_param`
+
+Outputs:
+
+- In-process prediction through:
+  - `getPrediction(predPos, predSize, intentProb)`
+  - `getPrediction(std::vector<dynamicPredictor::obstacle>&)`
+- Visualization topics:
+  - `dynamic_predictor/history_trajectories`
+  - `dynamic_predictor/predict_trajectories`
+  - `dynamic_predictor/intent_probability`
+  - `dynamic_predictor/var_points`
+  - `dynamic_predictor/pred_bbox`
+
+Intent enum:
+
+```cpp
+FORWARD, LEFT, RIGHT, STOP
+```
+
+Prediction shape used by MPC:
+
+```text
+predPos[obstacle][intent][time_step] -> Eigen::Vector3d
+predSize[obstacle][intent][time_step] -> Eigen::Vector3d
+intentProb[obstacle] -> Eigen::VectorXd
+```
+
+## MPC Dynamic Obstacle Path
+
+`autonomous_flight/include/autonomous_flight/mpcNavigation.cpp`
+
+When `use_predictor: true`:
+
+```text
+predictor_->getPrediction(predPos, predSize, intentProb)
+mpc_->updatePredObstacles(predPos, predSize, intentProb)
+mpc_->makePlanWithPred()
+```
+
+When `use_predictor: false`:
+
+```text
+map/fakeDetector dynamic obstacles
+mpc_->updateDynamicObstacles(obstaclesPos, obstaclesVel, obstaclesSize)
+mpc_->makePlan()
+```
+
+`trajectory_planner/include/trajectory_planner/mpcPlanner.cpp`
+
+Important methods:
+
+- `updateDynamicObstacles`: repeats current obstacle state over the MPC horizon.
+- `updatePredObstacles`: validates predicted obstacle trajectories and stores intent probabilities.
+- `makePlanWithPred`: generates candidate trajectories for intent combinations and selects the best candidate.
+- `getIntentComb`: constructs intent combinations for the closest obstacle and max-probability intent for other obstacles.
+- `solveTraj`: formulates and solves the QP.
+- `updateObstacleParam`: converts dynamic/static obstacles into ellipsoid constraint parameters.
+- `castMPCToQPConstraintMatrix` and `castMPCToQPConstraintVectors`: add obstacle constraints to the QP.
+- `getSafetyScore`: scores candidate trajectories by static/dynamic obstacle proximity.
+
+Current dynamic obstacle safety expansion occurs in `updateObstacleParam`:
+
+```cpp
+osize[j](i,0) = dynamicObstaclesSize[i][j](0)/2 + dynamicSafetyDist_;
+osize[j](i,1) = dynamicObstaclesSize[i][j](1)/2 + dynamicSafetyDist_;
+osize[j](i,2) = dynamicObstaclesSize[i][j](2)/2 + dynamicSafetyDist_;
+```
+
+This is the most direct Stage 5 insertion point for replacing fixed dynamic margin with uncertainty-aware effective radius.
+
+## Key Topics
+
+UAV state:
+
+- `/CERLAB/quadcopter/pose_raw`
+- `/CERLAB/quadcopter/pose`
+- `/CERLAB/quadcopter/vel_raw`
+- `/CERLAB/quadcopter/vel`
+- `/CERLAB/quadcopter/acc_raw`
+- `/CERLAB/quadcopter/acc`
+- `/CERLAB/quadcopter/odom_raw`
+- `/CERLAB/quadcopter/odom`
+
+UAV control:
+
+- `/autonomous_flight/target_state`
+- `/CERLAB/quadcopter/cmd_acc`
+- `/CERLAB/quadcopter/cmd_vel`
+- `/CERLAB/quadcopter/setpoint_pose`
+
+Navigation/planning visualization:
+
+- `mpcNavigation/input_trajectory`
+- `mpcNavigation/mpc_trajectory`
+- `mpc_planner/mpc_trajectory`
+- `mpc_planner/traj_history`
+- `mpc_planner/candidate_trajectories`
+- `mpc_planner/dynamic_obstacles`
+- `mpc_planner/static_obstacles`
+
+Dynamic obstacle visualization:
+
+- `onboard_detector/GT_obstacle_bbox`
+- `onboard_detector/history_trajectories`
+- `dynamic_predictor/history_trajectories`
+- `dynamic_predictor/predict_trajectories`
+- `dynamic_predictor/intent_probability`
+- `dynamic_predictor/var_points`
+- `dynamic_predictor/pred_bbox`
+
+## Initial Insertion-Point Candidates
+
+### Candidate A: Between detector/map and predictor
+
+Shape:
+
+```text
+box3D/history -> uncertainty-aware obstacle history -> dynamicPredictor
+```
+
+Pros:
+
+- Models perception uncertainty before intent prediction.
+- Useful for Stage 3 perception degradation and Stage 4 uncertainty representation.
+
+Risks:
+
+- Requires careful handling of history, delay, dropout, and association.
+- Could affect predictor behavior and make debugging harder.
+
+### Candidate B: Between predictor and MPC
+
+Shape:
+
+```text
+predPos, predSize, intentProb -> uncertainty-adjusted predSize/effective_radius -> mpcPlanner
+```
+
+Pros:
+
+- Minimal first algorithmic change.
+- Directly maps to `updatePredObstacles` and `updateObstacleParam`.
+- Easy to compare original Intent-MPC, fixed margin, and uncertainty-aware margin.
+
+Risks:
+
+- Uncertainty affects planning but not predictor intent probabilities.
+
+### Candidate C: Inside MPC obstacle constraint construction
+
+Shape:
+
+```text
+dynamicObstaclesSize + uncertainty terms -> osize in updateObstacleParam
+```
+
+Pros:
+
+- Smallest local Stage 5 code change.
+- Clear baseline against existing `dynamicSafetyDist_`.
+
+Risks:
+
+- If uncertainty needs per-obstacle metadata beyond size, `mpcPlanner` data structures must be extended first.
+
+## Current Recommendation
+
+For phased implementation:
+
+1. Stage 2 should add logging before any planner behavior changes.
+2. Stage 3 should implement perception degradation outside the planner.
+3. Stage 4 should define uncertainty fields and visualization.
+4. Stage 5 should first implement Candidate C as fixed/effective radius inflation, then consider Candidate B for predicted obstacle trajectories.
+
+This keeps each stage testable and avoids changing Intent-MPC behavior before metrics are available.
+

--- a/docs/stage1/insertion_point_design.md
+++ b/docs/stage1/insertion_point_design.md
@@ -1,0 +1,257 @@
+# Insertion Point Design for Uncertainty-Aware Planning
+
+## Goal
+
+The later research goal is to plan safely when multimodal perception is uncertain. The implementation should preserve the official Intent-MPC baseline and add switchable modes:
+
+- Original Intent-MPC.
+- Intent-MPC + fixed safety margin.
+- Uncertainty-aware Intent-MPC.
+
+## Candidate Ranking
+
+### Rank 1: MPC Obstacle Constraint Construction
+
+Insertion point:
+
+```text
+dynamicObstaclesSize + uncertainty terms
+  -> effective size / effective radius
+  -> mpcPlanner::updateObstacleParam
+  -> QP ellipsoid obstacle constraints
+```
+
+Primary file:
+
+- `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp`
+
+Key function:
+
+- `mpcPlanner::updateObstacleParam`
+
+Why this is ranked first:
+
+- It is the smallest behavior-changing insertion point.
+- It maps directly to the current fixed margin implementation.
+- It gives a clean baseline comparison:
+  - `dynamicSafetyDist_`
+  - larger fixed margin
+  - uncertainty-driven margin
+- It avoids changing intent prediction while Stage 2/3 metrics are still being built.
+
+Current fixed dynamic obstacle expansion:
+
+```cpp
+osize[j](i,0) = dynamicObstaclesSize[i][j](0)/2 + dynamicSafetyDist_;
+osize[j](i,1) = dynamicObstaclesSize[i][j](1)/2 + dynamicSafetyDist_;
+osize[j](i,2) = dynamicObstaclesSize[i][j](2)/2 + dynamicSafetyDist_;
+```
+
+Recommended Stage 5 evolution:
+
+```text
+base_half_size = dynamicObstaclesSize[i][j] / 2
+margin = fixed_margin or uncertainty_margin
+osize = base_half_size + margin
+```
+
+Then:
+
+```text
+uncertainty_margin =
+    alpha * position_uncertainty
+  + beta  * velocity_uncertainty
+  + gamma * delay
+  + delta * (1 - confidence)
+```
+
+Implementation note:
+
+This candidate requires Stage 4 to define how uncertainty metadata reaches `mpcPlanner`. If only size is available, `dynamicObstaclesSize` can be temporarily overloaded to carry effective size, but the cleaner design is to introduce a dedicated obstacle state structure first.
+
+### Rank 2: Between Predictor and MPC
+
+Insertion point:
+
+```text
+predPos / predSize / intentProb
+  -> uncertainty-adjusted predicted obstacles
+  -> mpcPlanner::updatePredObstacles
+```
+
+Primary files:
+
+- `autonomous_flight/include/autonomous_flight/mpcNavigation.cpp`
+- `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp`
+- `dynamic_predictor/include/dynamic_predictor/utils.h`
+
+Why this is useful:
+
+- It can adjust future obstacle sizes per prediction horizon step.
+- It aligns well with delay and velocity uncertainty.
+- It can treat different intents with different uncertainty growth.
+
+Risks:
+
+- Existing `dynamic_predictor::genTraj` already inflates `predSize` using trajectory variance and `zScore_`.
+- Additional perception uncertainty must be separated from prediction dispersion to avoid double counting.
+- It may require extending `dynamicPredictor::obstacle`.
+
+Recommended use:
+
+Use this after Candidate 1 works and metrics show fixed/effective radius is insufficient.
+
+### Rank 3: Between Detector/Map and Predictor
+
+Insertion point:
+
+```text
+box3D / obstacle history
+  -> perception_degradation_node or uncertainty wrapper
+  -> dynamicPredictor
+```
+
+Primary files:
+
+- `onboard_detector/include/onboard_detector/fakeDetector.cpp`
+- `onboard_detector/include/onboard_detector/dynamicDetector.cpp`
+- `map_manager/include/map_manager/dynamicMap.cpp`
+- future ROS node for perception degradation
+
+Why this matters:
+
+- It is the right conceptual location for perception degradation.
+- It can model dropout, delay, noise, false positives, and multimodal disagreement before prediction.
+- It supports paper experiments about perception uncertainty directly.
+
+Risks:
+
+- It changes predictor input distribution.
+- It may complicate debugging before experiment logging is stable.
+- Fake detector currently communicates with predictor in-process, not as a clean ROS obstacle topic.
+
+Recommended use:
+
+Implement in Stage 3 as an external degradation path or wrapper first. Avoid modifying `fakeDetector` deeply unless necessary.
+
+## Recommended Phased Plan
+
+### Stage 2: Metrics First
+
+Do not change planning behavior yet.
+
+Add logging for:
+
+- success
+- collision
+- min distance
+- path length
+- travel time
+- average speed
+- planning time
+- scenario name
+- method name
+- noise/delay/dropout/seed metadata
+
+Reason:
+
+Without a stable metrics layer, later algorithm changes cannot be defended in a paper.
+
+### Stage 3: Perception Degradation
+
+Build a configurable degradation node/interface:
+
+```text
+original obstacle state
+  -> perception_degradation_node
+  -> degraded obstacle state
+```
+
+Parameters:
+
+- `position_noise_std`
+- `velocity_noise_std`
+- `delay_ms`
+- `dropout_prob`
+- `false_positive_prob`
+- `confidence_noise`
+- `random_seed`
+
+Reason:
+
+This produces controlled failure modes while keeping the original planner available as baseline.
+
+### Stage 4: Uncertainty Representation
+
+Define a unified obstacle schema:
+
+```text
+Obstacle {
+  position
+  velocity
+  radius or size
+  confidence
+  covariance
+  source_modalities
+  effective_radius
+}
+```
+
+Also add RViz and CSV logging for:
+
+- raw obstacle size
+- uncertainty
+- effective risk radius
+
+### Stage 5: Planner Integration
+
+First implementation:
+
+```text
+dynamic obstacle size -> effective size -> updateObstacleParam
+```
+
+Second implementation:
+
+```text
+distance to high-uncertainty obstacle -> risk cost / trajectory score
+```
+
+Candidate cost insertion points:
+
+- `mpcPlanner::getSafetyScore`
+- candidate trajectory scoring in `makePlanWithPred`
+
+## Files Likely to Change Later
+
+Stage 2:
+
+- New experiment logging package or scripts.
+- Possibly `autonomous_flight` or a standalone monitor node subscribing to existing topics.
+
+Stage 3:
+
+- New perception degradation node/package.
+- Possible launch/yaml additions.
+
+Stage 4:
+
+- New message or C++ struct for uncertainty obstacle state.
+- RViz marker publisher.
+- CSV logging extensions.
+
+Stage 5:
+
+- `trajectory_planner/include/trajectory_planner/mpcPlanner.h`
+- `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp`
+- `autonomous_flight/include/autonomous_flight/mpcNavigation.cpp`
+- Config yaml for planner mode selection.
+
+## Guardrails
+
+- Keep original Intent-MPC mode as default.
+- Add method flags rather than replacing existing logic.
+- Keep fixed safety margin as a required intermediate baseline.
+- Do not merge uncertainty modeling into predictor variance without documenting the distinction.
+- Every planning change must be paired with metrics and scenario configs.
+

--- a/docs/stage1/stage1_execution_prompt.md
+++ b/docs/stage1/stage1_execution_prompt.md
@@ -1,0 +1,116 @@
+# Stage 1 Execution Prompt
+
+Use this prompt when asking an AI coding/research agent to reproduce or extend the Stage 1 code-reading work.
+
+```text
+你是一个严谨的软件工程和机器人研究助手。当前仓库是 Intent-MPC 的复现分支，用于论文方向：
+
+“基于多模态感知不确定性的无人机动态障碍物安全避障方法研究”。
+
+当前任务是完成 Stage 1：梳理 Intent-MPC 数据流，目标是找到后续接入多模态感知不确定性和安全规划改进的最小插入点。
+
+约束：
+- 不修改算法代码。
+- 不修改 planner 行为。
+- 只做代码阅读、运行接口梳理和文档输出。
+- 所有结论都要绑定到具体文件、函数和必要的行号。
+- 若发现阶段 0 稳定性修复，只记录其影响，不把它描述成算法创新。
+
+仓库路径：
+`/home/ubuntu2204/catkin_ws/src/Intent-MPC`
+
+已知阶段 0 状态：
+- Docker ROS Noetic 环境可运行。
+- 官方 demo 可启动：
+  - `roslaunch uav_simulator start.launch`
+  - `roslaunch autonomous_flight intent_mpc_demo.launch`
+- 轻量可视化入口：
+  - `roslaunch autonomous_flight intent_mpc_demo_fast_visual.launch`
+- 阶段 0 报告：
+  - `docs/stage0/Intent_MPC_stage0_report.md`
+
+Stage 1 需要完成的问题：
+
+1. launch 和运行时模块图
+   - 阅读：
+     - `uav_simulator/launch/start.launch`
+     - `autonomous_flight/launch/intent_mpc_demo.launch`
+     - `autonomous_flight/launch/intent_mpc_demo_fast_visual.launch`
+     - `tracking_controller/launch/tracking_controller.launch`
+   - 输出：
+     - Gazebo/UAV/TF/RViz 如何启动。
+     - `mpc_navigation_node`、`tracking_controller_node`、Gazebo plugin 的关系。
+     - 关键 ROS topic：UAV odom、target state、cmd_acc、MPC trajectory、dynamic obstacle visualization。
+
+2. 动态障碍物来源
+   - 阅读：
+     - `onboard_detector/include/onboard_detector/fakeDetector.cpp`
+     - `onboard_detector/include/onboard_detector/fakeDetector.h`
+     - `onboard_detector/include/onboard_detector/utils.h`
+     - `map_manager/include/map_manager/dynamicMap.cpp`
+     - `map_manager/include/map_manager/dynamicMap.h`
+   - 输出：
+     - 官方 demo 的动态障碍物来自 `/gazebo/model_states`。
+     - fake detector 如何筛选 `person` / `dynamic_box` / `dynamic_cylinder`。
+     - `box3D` 字段含义。
+     - fake detector 如何计算位置、速度、加速度、尺寸和历史轨迹。
+
+3. `dynamic_predictor` 输入输出
+   - 阅读：
+     - `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.cpp`
+     - `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.h`
+     - `dynamic_predictor/include/dynamic_predictor/utils.h`
+     - `autonomous_flight/cfg/mpc_navigation/predictor_param.yaml`
+   - 输出：
+     - 输入历史：`posHist_`、`velHist_`、`accHist_`、`sizeHist_`。
+     - 输出格式：`predPos[obstacle][intent][time_step]`、`predSize[...]`、`intentProb[obstacle]`。
+     - 意图类型：`FORWARD`、`LEFT`、`RIGHT`、`STOP`。
+     - 预测结果如何通过 `getPrediction()` 给 MPC。
+
+4. MPC 动态障碍物处理
+   - 阅读：
+     - `autonomous_flight/include/autonomous_flight/mpcNavigation.cpp`
+     - `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp`
+     - `trajectory_planner/include/trajectory_planner/mpcPlanner.h`
+     - `autonomous_flight/cfg/mpc_navigation/planner_param.yaml`
+   - 输出：
+     - `use_predictor=true` 时的数据链：
+       `predictor_->getPrediction -> mpc_->updatePredObstacles -> mpc_->makePlanWithPred`
+     - `use_predictor=false` 时的数据链：
+       `getDynamicObstacles -> mpc_->updateDynamicObstacles -> mpc_->makePlan`
+     - `updatePredObstacles` 如何整理预测障碍物。
+     - `getIntentComb` 如何构造候选 intent 组合。
+     - `solveTraj` 如何把障碍物转成 QP 约束。
+     - `updateObstacleParam` 中动态障碍物安全半径如何由尺寸和 `dynamicSafetyDist_` 构造。
+
+5. 插入点设计
+   - 给出至少 3 个候选：
+     - detector/map 和 predictor 之间。
+     - predictor 和 MPC 之间。
+     - MPC obstacle constraint construction 内部。
+   - 对每个候选写明：
+     - 适合哪个阶段。
+     - 优点。
+     - 风险。
+     - 需要改哪些文件。
+   - 最后给出推荐路线：
+     - Stage 2 先做日志系统。
+     - Stage 3 做感知退化节点。
+     - Stage 4 定义 uncertainty obstacle schema。
+     - Stage 5 先接入 effective radius / fixed margin，再考虑风险代价。
+
+输出文件：
+- `docs/stage1/stage1_final_report.md`
+- `docs/stage1/insertion_point_design.md`
+- 必要时更新 `docs/stage1/README.md`
+
+验收标准：
+- launch tree 和 runtime node graph 已记录。
+- UAV pose/velocity/control/planning topics 已记录。
+- 动态障碍物生成路径已记录。
+- `dynamic_predictor` 输入输出格式已记录。
+- MPC 动态障碍物约束路径已记录。
+- 候选插入点已排序。
+- 阶段 1 最终报告完成。
+```
+

--- a/docs/stage1/stage1_final_report.md
+++ b/docs/stage1/stage1_final_report.md
@@ -1,0 +1,416 @@
+# Stage 1 Final Report: Intent-MPC Data Flow
+
+## 1. Objective
+
+Stage 1 answers one question:
+
+> Where should uncertainty-aware dynamic obstacle planning be inserted into Intent-MPC with the least disruption?
+
+This report is analysis-only. It does not modify the algorithm.
+
+## 2. Scope and Sources
+
+Main sources read:
+
+- `uav_simulator/launch/start.launch`
+- `autonomous_flight/launch/intent_mpc_demo.launch`
+- `autonomous_flight/include/autonomous_flight/flightBase.cpp`
+- `autonomous_flight/include/autonomous_flight/mpcNavigation.cpp`
+- `onboard_detector/include/onboard_detector/fakeDetector.cpp`
+- `onboard_detector/include/onboard_detector/utils.h`
+- `map_manager/include/map_manager/dynamicMap.cpp`
+- `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.cpp`
+- `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.h`
+- `dynamic_predictor/include/dynamic_predictor/utils.h`
+- `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp`
+- `trajectory_planner/include/trajectory_planner/mpcPlanner.h`
+- `tracking_controller/include/tracking_controller/trackingController.cpp`
+- `docs/stage0/Intent_MPC_stage0_report.md`
+
+Stage 0 runtime validation is reused for node/topic evidence. No new algorithm run was required for this stage.
+
+## 3. Launch and Runtime Graph
+
+Official launch sequence:
+
+```bash
+roslaunch uav_simulator start.launch
+roslaunch autonomous_flight intent_mpc_demo.launch
+```
+
+`uav_simulator/launch/start.launch`:
+
+- Selects `uav_simulator/worlds/generated_env/generated_env.world` as the demo world.
+- Starts Gazebo through `gazebo_ros/empty_world.launch`.
+- Loads the UAV URDF.
+- Spawns `quadcopter` at `(0.0, 7.0, 0.1)` with yaw `-3.14`.
+- Throttles raw simulator state to 30 Hz.
+- Starts UAV TF and keyboard control.
+
+Source evidence:
+
+- World selection: `uav_simulator/launch/start.launch:64`
+- Gazebo include: `uav_simulator/launch/start.launch:67`
+- URDF selection: `uav_simulator/launch/start.launch:78-85`
+- State throttles: `uav_simulator/launch/start.launch:90-93`
+- UAV spawn: `uav_simulator/launch/start.launch:94`
+- TF include: `uav_simulator/launch/start.launch:97-99`
+
+`autonomous_flight/launch/intent_mpc_demo.launch`:
+
+- Loads controller, fake detector, flight base, planner, map, detector, and predictor parameters.
+- Starts `tracking_controller_node`.
+- Starts `mpc_navigation_node`.
+- Starts RViz through `remote_control/launch/mpc_navigation_rviz.launch`.
+
+Source evidence:
+
+- Parameter loading: `autonomous_flight/launch/intent_mpc_demo.launch:2-8`
+- Nodes: `autonomous_flight/launch/intent_mpc_demo.launch:10-11`
+- RViz include: `autonomous_flight/launch/intent_mpc_demo.launch:13`
+
+Stage 0 runtime nodes:
+
+```text
+/gazebo
+/gazebo_gui
+/gt_acc_throttle
+/gt_odom_throttle
+/gt_pose_throttle
+/gt_vel_throttle
+/keyboard_control
+/mpc_navigation_node
+/quadcopterTF
+/rviz1
+/tracking_controller_node
+```
+
+## 4. Key ROS Topics
+
+UAV state:
+
+- `/CERLAB/quadcopter/pose_raw`
+- `/CERLAB/quadcopter/pose`
+- `/CERLAB/quadcopter/vel_raw`
+- `/CERLAB/quadcopter/vel`
+- `/CERLAB/quadcopter/acc_raw`
+- `/CERLAB/quadcopter/acc`
+- `/CERLAB/quadcopter/odom_raw`
+- `/CERLAB/quadcopter/odom`
+
+UAV control:
+
+- `/CERLAB/quadcopter/setpoint_pose`
+- `/autonomous_flight/target_state`
+- `/CERLAB/quadcopter/cmd_acc`
+- `/CERLAB/quadcopter/cmd_vel`
+
+Planning:
+
+- `/mpcNavigation/input_trajectory`
+- `/mpcNavigation/mpc_trajectory`
+- `/mpc_planner/mpc_trajectory`
+- `/mpc_planner/traj_history`
+- `/mpc_planner/candidate_trajectories`
+- `/mpc_planner/static_obstacles`
+- `/mpc_planner/dynamic_obstacles`
+
+Dynamic obstacle and prediction visualization:
+
+- `/onboard_detector/GT_obstacle_bbox`
+- `/onboard_detector/history_trajectories`
+- `/dynamic_predictor/history_trajectories`
+- `/dynamic_predictor/predict_trajectories`
+- `/dynamic_predictor/intent_probability`
+- `/dynamic_predictor/var_points`
+- `/dynamic_predictor/pred_bbox`
+
+Controller evidence:
+
+- `tracking_controller` subscribes `/CERLAB/quadcopter/odom` and `/autonomous_flight/target_state`.
+- In simulation mode it publishes `/CERLAB/quadcopter/cmd_acc`.
+
+Source evidence:
+
+- `tracking_controller/include/tracking_controller/trackingController.cpp:181-183`
+- `tracking_controller/include/tracking_controller/trackingController.cpp:207-218`
+
+## 5. High-Level Data Flow
+
+Official demo in fake detector + predictor mode:
+
+```text
+Gazebo dynamic models
+  -> /gazebo/model_states
+  -> onboardDetector::fakeDetector
+  -> obstacle history: pos/vel/acc/size
+  -> dynamicPredictor::predictor
+  -> predPos / predSize / intentProb
+  -> trajPlanner::mpcPlanner::updatePredObstacles
+  -> mpcPlanner::makePlanWithPred
+  -> /mpcNavigation/mpc_trajectory
+  -> /autonomous_flight/target_state
+  -> tracking_controller_node
+  -> /CERLAB/quadcopter/cmd_acc
+  -> Gazebo quadcopter plugin
+```
+
+The `use_predictor=false` fallback path:
+
+```text
+fakeDetector or dynamicMap
+  -> obstaclesPos / obstaclesVel / obstaclesSize
+  -> mpcPlanner::updateDynamicObstacles
+  -> mpcPlanner::makePlan
+```
+
+Source evidence:
+
+- Predictor initialized and connected to fake detector: `autonomous_flight/include/autonomous_flight/mpcNavigation.cpp:140-144`
+- Planner modules initialized: `autonomous_flight/include/autonomous_flight/mpcNavigation.cpp:147-163`
+- Predictor path: `autonomous_flight/include/autonomous_flight/mpcNavigation.cpp:293-318`
+- Non-predictor path: `autonomous_flight/include/autonomous_flight/mpcNavigation.cpp:300-320`
+- Target publication chain: `autonomous_flight/include/autonomous_flight/mpcNavigation.cpp:331-334`
+
+## 6. Dynamic Obstacle Generation
+
+In the official demo, dynamic obstacles are simulated in Gazebo and read by `fakeDetector`.
+
+`fakeDetector` behavior:
+
+- Subscribes `/gazebo/model_states` when mocap is not used.
+- Reads target prefixes from `target_obstacle`.
+- Official stage 0 config sets target prefixes to `person`, `dynamic_box`, and `dynamic_cylinder`.
+- Estimates velocity and acceleration by differencing Gazebo model state across time.
+- Parses object size from Gazebo model name strings.
+- Stores obstacle history for prediction.
+- Publishes ground-truth obstacle boxes and history trajectories.
+
+Source evidence:
+
+- Target prefix parameter: `onboard_detector/include/onboard_detector/fakeDetector.cpp:23-25`
+- Gazebo model state subscription: `onboard_detector/include/onboard_detector/fakeDetector.cpp:55-60`
+- Odom subscription and visualization topics: `onboard_detector/include/onboard_detector/fakeDetector.cpp:62-70`
+- Position extraction: `onboard_detector/include/onboard_detector/fakeDetector.cpp:144-156`
+- Velocity and acceleration estimation: `onboard_detector/include/onboard_detector/fakeDetector.cpp:172-196`
+- Size parsing from model names: `onboard_detector/include/onboard_detector/fakeDetector.cpp:207-223`
+- History update: `onboard_detector/include/onboard_detector/fakeDetector.cpp:311-320`
+
+Core obstacle struct:
+
+```cpp
+box3D {
+  double x, y, z;
+  double x_width, y_width, z_width;
+  double id;
+  double Vx, Vy, Vz;
+  double Ax, Ay, Az;
+  bool is_human;
+  bool is_dynamic;
+  bool fix_size;
+  bool is_dynamic_candidate;
+  bool is_estimated;
+}
+```
+
+Source: `onboard_detector/include/onboard_detector/utils.h`
+
+Real detector path:
+
+- `dynamicMap` creates `onboardDetector::dynamicDetector`.
+- `dynamicMap::getDynamicObstacles` converts `box3D` to separate `Eigen::Vector3d` arrays for position, velocity, and size.
+
+Source evidence:
+
+- Detector ownership: `map_manager/include/map_manager/dynamicMap.cpp:23-31`
+- Dynamic obstacle conversion: `map_manager/include/map_manager/dynamicMap.cpp:48-60`
+
+## 7. Dynamic Predictor I/O
+
+`dynamicPredictor::predictor` receives history and outputs multiple possible intent-conditioned future trajectories.
+
+Inputs:
+
+- `posHist_`
+- `velHist_`
+- `accHist_`
+- `sizeHist_`
+
+Output members:
+
+- `posPred_`
+- `sizePred_`
+- `intentProb_`
+
+Source evidence:
+
+- Members: `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.h:56-64`
+- Fake/real detector history input: `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.cpp:163-170`
+- Intent probability and trajectory prediction update: `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.cpp:171-187`
+- Public getter: `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.h:101-103`
+
+Intent types:
+
+```cpp
+FORWARD, LEFT, RIGHT, STOP
+```
+
+Prediction tensor format used by MPC:
+
+```text
+predPos[obstacle][intent][time_step] -> Eigen::Vector3d
+predSize[obstacle][intent][time_step] -> Eigen::Vector3d
+intentProb[obstacle] -> Eigen::VectorXd
+```
+
+Prediction generation:
+
+- `predTraj` loops over obstacle and intent.
+- `genPoints` dispatches to forward, turning, or stop models.
+- `genTraj` computes mean trajectory and inflates predicted size by variance through `zScore_`.
+
+Source evidence:
+
+- Per-obstacle/per-intent loop: `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.cpp:285-331`
+- Intent model dispatch: `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.cpp:333-351`
+- Forward model: `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.cpp:353-404`
+- Turning model: `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.cpp:406-488`
+- Stop model: `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.cpp:490-503`
+- Mean and variance inflation: `dynamic_predictor/include/dynamic_predictor/dynamicPredictor.cpp:505-540`
+
+Important observation:
+
+`dynamic_predictor` already expands `predSize` from prediction dispersion using `zScore_`. Later uncertainty-aware planning should avoid double-counting this term unless it is explicitly separated from perception uncertainty.
+
+## 8. MPC Dynamic Obstacle Handling
+
+MPC stores dynamic obstacles as horizon-indexed arrays:
+
+- `dynamicObstaclesPos_`
+- `dynamicObstaclesVel_`
+- `dynamicObstaclesSize_`
+- `obPredPos_`
+- `obPredSize_`
+- `obIntentProb_`
+
+Source evidence:
+
+- Members: `trajectory_planner/include/trajectory_planner/mpcPlanner.h:69-76`
+- Public update methods: `trajectory_planner/include/trajectory_planner/mpcPlanner.h:117-123`
+
+Non-predictor path:
+
+- `updateDynamicObstacles` repeats current obstacle state over the whole horizon.
+
+Source: `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp:268-293`
+
+Predictor path:
+
+- `updatePredObstacles` validates shape, pads short trajectories, and stores prediction tensors.
+- It also initializes `dynamicObstaclesPos_` and `dynamicObstaclesSize_` from the forward intent at time step 0.
+
+Source: `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp:295-368`
+
+Planning with prediction:
+
+- `makePlanWithPred` builds candidate obstacle intent combinations.
+- It solves candidate QPs under a time budget.
+- It scores candidates using consistency, detour, and safety terms.
+- It selects the best candidate trajectory.
+
+Source evidence:
+
+- `makePlanWithPred`: `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp:560-666`
+- `getIntentComb`: `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp:718-802`
+- Candidate scoring entry: `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp:804-810`
+
+QP obstacle constraints:
+
+- `solveTraj` calls `updateObstacleParam`, `castMPCToQPConstraintMatrix`, and `castMPCToQPConstraintVectors`.
+- `castMPCToQPConstraintMatrix` inserts linearized ellipsoid obstacle constraints.
+- `castMPCToQPConstraintVectors` computes lower obstacle bounds.
+
+Source evidence:
+
+- QP setup path: `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp:370-432`
+- Constraint matrix obstacle block: `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp:1006-1094`
+- Constraint vector obstacle block: `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp:1136-1167`
+
+Obstacle size/safety expansion:
+
+```cpp
+osize[j](i,0) = dynamicObstaclesSize[i][j](0)/2 + this->dynamicSafetyDist_;
+osize[j](i,1) = dynamicObstaclesSize[i][j](1)/2 + this->dynamicSafetyDist_;
+osize[j](i,2) = dynamicObstaclesSize[i][j](2)/2 + this->dynamicSafetyDist_;
+```
+
+Source evidence:
+
+- Dynamic obstacle ellipsoid size: `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp:1170-1206`
+- Static obstacle ellipsoid size: `trajectory_planner/include/trajectory_planner/mpcPlanner.cpp:1208-1217`
+
+This is the most direct future insertion point for `r_eff`.
+
+## 9. Key Parameters
+
+`autonomous_flight/cfg/mpc_navigation/flight_base.yaml`:
+
+- `simulation: true`
+- `use_fake_detector: true`
+- `use_predictor: true`
+- `desired_velocity: 1.5`
+- `desired_acceleration: 1.5`
+- `use_predefined_goal: true`
+- `execute_path_times: 10`
+
+`autonomous_flight/cfg/mpc_navigation/planner_param.yaml`:
+
+- `mpc_planner/horizon: 30`
+- `mpc_planner/static_safety_dist: 0.8`
+- `mpc_planner/dynamic_safety_dist: 0.6`
+- `mpc_planner/dynamic_constraint_slack_ratio: 0.2`
+
+`autonomous_flight/cfg/mpc_navigation/predictor_param.yaml`:
+
+- `prediction_size: 30`
+- `prediction_time_step: 0.1`
+- `prediction_z_score: 0.674`
+- `min_turning_time: 2.0`
+- `max_turning_time: 3.0`
+
+`autonomous_flight/cfg/mpc_navigation/fake_detector_param.yaml`:
+
+- `target_obstacle: ["person", "dynamic_box", "dynamic_cylinder"]`
+- `odom_topic: "/CERLAB/quadcopter/odom"`
+- `history_size: 100`
+
+## 10. Stage 1 Conclusions
+
+Main findings:
+
+- Official demo dynamic obstacles are not ROS messages first; they are Gazebo models read from `/gazebo/model_states`.
+- The fake detector converts Gazebo model state to `box3D`, including estimated velocity and acceleration.
+- `dynamic_predictor` consumes obstacle history and outputs predicted position/size trajectories per intent plus intent probabilities.
+- `mpcNavigation` passes prediction directly into `mpcPlanner`.
+- MPC represents obstacles as ellipsoid constraints in QP.
+- Existing dynamic obstacle safety is a fixed `dynamicSafetyDist_` added to half-sizes in `updateObstacleParam`.
+
+Recommended research route:
+
+1. Stage 2: implement metrics/logging before changing behavior.
+2. Stage 3: implement perception degradation outside planner.
+3. Stage 4: define uncertainty obstacle schema and RViz/logging.
+4. Stage 5: first modify the effective dynamic obstacle radius/size path, then optionally add risk costs.
+
+## 11. Stage 1 Acceptance
+
+- [x] Launch tree and runtime node graph documented.
+- [x] UAV pose/velocity/control/planning topics documented.
+- [x] Dynamic obstacle generation path documented.
+- [x] `dynamic_predictor` input/output format documented.
+- [x] MPC dynamic obstacle constraint path documented.
+- [x] Candidate uncertainty insertion points ranked.
+- [x] Stage 1 final report completed.
+
+Conclusion: Stage 1 acceptance criteria are met.
+


### PR DESCRIPTION
## Goal

Complete Stage 1 dataflow analysis for the Intent-MPC reproduction branch.

## Changes

- Added reusable Stage 1 execution prompt.
- Added final dataflow report with launch/module/topic/source evidence.
- Added ranked uncertainty-aware planning insertion-point design.
- Updated Stage 1 README acceptance checklist.

## Notes

No algorithm code was changed. This PR targets `stage0-reproduction-stability` because `main` currently contains the roadmap README only and has unrelated history. That repository-management issue remains tracked in #18.

## Validation

- `git diff --check` passed.
- Stage 1 issues #2-#6 were closed after documentation was pushed.
