### PR TITLE
Stage 3: perception degradation module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+experiment_logs/

--- a/docs/project_management/github_workflow.md
+++ b/docs/project_management/github_workflow.md
@@ -11,9 +11,9 @@ The `main` branch currently stores the high-level research plan. The reproductio
 - `main`: stable project overview, roadmap, and accepted stage summaries.
 - `stage0-reproduction-stability`: stage 0 reproduction, Docker/ROS Noetic environment, runtime stability fixes, and validation report.
 - `stage1-code-reading-baseline`: stage 1 code-reading branch for Intent-MPC data flow, ROS interfaces, and algorithm insertion-point analysis.
+- `stage2-experiment-logging`: stage 2 experiment logging package, CSV schema, summary, and plotting scripts.
+- `stage3-perception-degradation`: stage 3 perception degradation node, degraded obstacle messages, RViz markers, and CSV samples.
 - Future branches:
-  - `stage2-experiment-logging`
-  - `stage3-perception-degradation`
   - `stage4-multimodal-uncertainty`
   - `stage5-safety-local-planner`
   - `stage6-paper-experiment-matrix`
@@ -38,7 +38,17 @@ Created milestones:
 - `Stage 6 - Paper Experiment Matrix`
 - `Stage 7 - Paper Materials`
 
-`Stage 0 - Reproduction` is closed because the official demo was reproduced and validated on this machine.
+Closed milestones:
+
+- `Stage 0 - Reproduction`
+- `Stage 1 - Intent-MPC Data Flow`
+- `Stage 2 - Experiment Logging`
+
+Current active milestone:
+
+- `Stage 3 - Perception Degradation`
+
+Stage 3 scope is deliberately limited to an external degraded perception stream. Planner consumption of degraded/uncertain obstacles remains reserved for Stage 5.
 
 ## GitHub Issues
 
@@ -77,4 +87,3 @@ Before merging stage work into `main`, decide how to reconcile this:
 2. Update `main` to the full codebase plus the project roadmap.
 
 This is tracked in [#18](https://github.com/zsz15964443357-lab/UAV/issues/18).
-

--- a/docs/stage3/README.md
+++ b/docs/stage3/README.md
@@ -1,0 +1,92 @@
+# Stage 3: Perception Degradation
+
+Goal: simulate unreliable obstacle perception before changing the local planner.
+
+This stage implements a configurable external ROS node:
+
+```text
+Gazebo / simulation obstacle ground truth
+        -> perception_degradation_node
+        -> degraded obstacle topic + RViz markers + CSV samples
+```
+
+The node does not change Intent-MPC planner behavior yet. It creates the degraded obstacle interface that later stages can connect to uncertainty modeling and planner constraints.
+
+## Artifacts
+
+- `perception_degradation`: new ROS package.
+- `perception_degradation/msg/DegradedObstacle.msg`: degraded obstacle state.
+- `perception_degradation/msg/DegradedObstacleArray.msg`: degraded obstacle array plus dropout/false-positive counts.
+- `perception_degradation/scripts/perception_degradation_node.py`: configurable degradation node.
+- `perception_degradation/config/stage3_default.yaml`: default parameters.
+- `perception_degradation/launch/run_degradation.launch`: start degradation node.
+- `perception_degradation/launch/run_degradation_with_recorder.launch`: start degradation node plus Stage 2 metric recorder.
+
+## Supported Parameters
+
+- `position_noise_std`
+- `velocity_noise_std`
+- `delay_ms`
+- `dropout_prob`
+- `false_positive_prob`
+- `confidence_noise`
+- `random_seed`
+
+Additional parameters configure target obstacle prefixes, output CSV location, false-positive area, marker topics, confidence range, and publish rate.
+
+## Runtime Usage
+
+Start the official demo first:
+
+```bash
+source /opt/ros/noetic/setup.bash
+source ~/catkin_ws/devel/setup.bash
+roslaunch uav_simulator start.launch
+roslaunch autonomous_flight intent_mpc_demo_fast_visual.launch
+```
+
+Start degradation observation:
+
+```bash
+source /opt/ros/noetic/setup.bash
+source ~/catkin_ws/devel/setup.bash
+roslaunch perception_degradation run_degradation.launch \
+  position_noise_std:=0.1 \
+  velocity_noise_std:=0.2 \
+  delay_ms:=100 \
+  dropout_prob:=0.1 \
+  false_positive_prob:=0.05 \
+  confidence_noise:=0.1 \
+  random_seed:=1
+```
+
+The main output topic is:
+
+```text
+/perception_degradation/degraded_obstacles
+```
+
+RViz marker topic:
+
+```text
+/perception_degradation/degraded_obstacle_markers
+```
+
+CSV output:
+
+```text
+~/catkin_ws/experiment_logs/stage3_degraded_obstacles.csv
+```
+
+## Current Stage Boundary
+
+Stage 3 produces degraded obstacle states but does not feed them into MPC. The official demo still uses the original fake detector path. Planner consumption of uncertainty-aware obstacle states belongs to Stage 5.
+
+## Acceptance Checklist
+
+- [x] Degraded obstacle message schema exists.
+- [x] Configurable degradation node exists.
+- [x] Position noise, velocity noise, delay, dropout, false positives, confidence noise, and random seed are implemented.
+- [x] RViz marker output exists.
+- [x] Per-obstacle degradation CSV output exists.
+- [x] No planner behavior is changed.

--- a/docs/stage3/stage3_design.md
+++ b/docs/stage3/stage3_design.md
@@ -1,0 +1,94 @@
+# Stage 3 Design
+
+## Scope
+
+Stage 3 creates a configurable degraded perception stream from simulation ground truth.
+
+Current input:
+
+```text
+/gazebo/model_states
+```
+
+Current outputs:
+
+```text
+/perception_degradation/degraded_obstacles
+/perception_degradation/degraded_obstacle_markers
+~/catkin_ws/experiment_logs/stage3_degraded_obstacles.csv
+```
+
+This is intentionally outside the planner. It lets us validate noise, delay, dropout, false positives, and confidence behavior before modifying Intent-MPC internals.
+
+## Message Schema
+
+`DegradedObstacle` stores:
+
+- `id`
+- `label`
+- `position`
+- `velocity`
+- `size`
+- `radius`
+- `confidence`
+- `position_noise_std`
+- `velocity_noise_std`
+- `delay_ms`
+- `is_false_positive`
+- `source_modalities`
+
+`DegradedObstacleArray` stores:
+
+- message header
+- obstacle array
+- raw obstacle count
+- dropped obstacle count
+- false-positive count
+
+## Degradation Model
+
+Position noise:
+
+```text
+p_degraded = p_raw + N(0, position_noise_std)
+```
+
+Velocity noise:
+
+```text
+v_degraded = v_raw + N(0, velocity_noise_std)
+```
+
+Delay:
+
+```text
+output(t) = degraded(raw_obstacles(t - delay_ms))
+```
+
+Dropout:
+
+```text
+publish obstacle with probability 1 - dropout_prob
+```
+
+False positive:
+
+```text
+with probability false_positive_prob, add a synthetic obstacle
+```
+
+Confidence:
+
+```text
+confidence = clamp(base_confidence + N(0, confidence_noise),
+                   min_confidence,
+                   max_confidence)
+```
+
+## Reproducibility
+
+All random sampling uses a local Python random generator seeded by `random_seed`.
+
+## Planner Interface Boundary
+
+The official Intent-MPC path currently obtains dynamic obstacles through detector/map C++ objects, not through a generic obstacle topic. Feeding degraded obstacles into MPC would require an integration point in `autonomous_flight` or detector wrappers. That belongs to Stage 5. Stage 3 only provides and validates the degraded obstacle stream.

--- a/docs/stage3/stage3_execution_prompt.md
+++ b/docs/stage3/stage3_execution_prompt.md
@@ -1,0 +1,60 @@
+# Stage 3 Execution Prompt
+
+你现在要完成阶段 3：实现感知退化模块。
+
+研究背景：本仓库用于硕士研究“基于多模态感知不确定性的无人机动态障碍物安全避障方法研究”。阶段 0 已复现 Intent-MPC 官方 demo，阶段 1 已梳理数据流，阶段 2 已完成实验指标记录系统。阶段 3 要在不改规划器算法的前提下，先构造可配置的感知退化输出，为阶段 4 的不确定性表示和阶段 5 的安全规划接入做准备。
+
+约束：
+
+- 不修改 Intent-MPC 的 MPC、控制器、动态预测器或原 fake detector 算法逻辑。
+- 允许新增 ROS package、msg、launch、config、脚本和文档。
+- 输出应能被后续阶段作为统一 obstacle state 的输入。
+- 需要保持 ROS Noetic / Python 3 / catkin 可构建。
+- 每次新阶段开始时，根据最新进度更新阶段内容、范围边界和 GitHub 跟踪状态。
+
+任务：
+
+1. 读取 GitHub `main` 最新 README，确认阶段 3 与多模态研究主线。
+2. 从 `stage2-experiment-logging` 创建 `stage3-perception-degradation` 分支。
+3. 新增 ROS 包 `perception_degradation`。
+4. 定义消息：
+   - `DegradedObstacle.msg`
+   - `DegradedObstacleArray.msg`
+5. 实现 `perception_degradation_node.py`：
+   - 订阅 `/gazebo/model_states`。
+   - 筛选 `person`、`dynamic_box`、`dynamic_cylinder`。
+   - 解析障碍物位置、速度、尺寸和半径。
+   - 支持 `position_noise_std`。
+   - 支持 `velocity_noise_std`。
+   - 支持 `delay_ms`。
+   - 支持 `dropout_prob`。
+   - 支持 `false_positive_prob`。
+   - 支持 `confidence_noise`。
+   - 支持 `random_seed` 以保证可复现实验。
+   - 发布退化后的障碍物数组 topic。
+   - 发布 RViz marker。
+   - 可选写入逐障碍物 CSV。
+6. 增加 launch/config：
+   - `stage3_default.yaml`
+   - `run_degradation.launch`
+   - `run_degradation_with_recorder.launch`
+7. 写阶段 3 文档：
+   - 使用方式。
+   - 参数说明。
+   - 输出 topic / CSV。
+   - 当前阶段边界：只生成退化感知，不接入 MPC。
+   - 后续阶段如何接入 Stage 4 和 Stage 5。
+8. 验证：
+   - `python3 -m py_compile perception_degradation/scripts/perception_degradation_node.py`
+   - Docker / ROS Noetic 内 `catkin_make`
+   - `roslaunch perception_degradation run_degradation.launch --nodes`
+   - ROS smoke test：发布合成 `/gazebo/model_states`，确认输出 degraded topic、marker、CSV。
+9. 提交并推送到 GitHub，创建 PR，更新 Stage 3 issues/milestone。
+
+验收标准：
+
+- 新包能被 catkin 发现并构建。
+- 退化节点能发布 `/perception_degradation/degraded_obstacles`。
+- 参数对输出有实际影响。
+- 能生成 RViz marker 和 CSV。
+- 不改变官方 demo 的规划行为。

--- a/docs/stage3/stage3_final_report.md
+++ b/docs/stage3/stage3_final_report.md
@@ -1,0 +1,95 @@
+# Stage 3 Final Report
+
+## Goal
+
+Implement a configurable perception degradation module for simulated dynamic obstacles.
+
+## Implementation
+
+Added ROS package:
+
+```text
+perception_degradation
+```
+
+Main files:
+
+- `perception_degradation/msg/DegradedObstacle.msg`
+- `perception_degradation/msg/DegradedObstacleArray.msg`
+- `perception_degradation/scripts/perception_degradation_node.py`
+- `perception_degradation/config/stage3_default.yaml`
+- `perception_degradation/launch/run_degradation.launch`
+- `perception_degradation/launch/run_degradation_with_recorder.launch`
+
+## Supported Degradation
+
+- Position noise
+- Velocity noise
+- Perception delay
+- Dropout
+- False positives
+- Confidence noise
+- Reproducible random seed
+
+## Outputs
+
+Topic:
+
+```text
+/perception_degradation/degraded_obstacles
+```
+
+RViz:
+
+```text
+/perception_degradation/degraded_obstacle_markers
+```
+
+CSV:
+
+```text
+stage3_degraded_obstacles.csv
+```
+
+## Validation
+
+Completed checks:
+
+```bash
+python3 -m py_compile perception_degradation/scripts/perception_degradation_node.py
+```
+
+Result: passed.
+
+```bash
+catkin_make
+```
+
+Result: passed in the Stage 0 Docker/ROS Noetic container. `perception_degradation` was discovered by catkin, both messages were generated, and the node wrapper was installed into the devel space.
+
+```bash
+roslaunch perception_degradation run_degradation.launch --nodes
+```
+
+Result: passed, launch resolves `/perception_degradation_node`.
+
+ROS smoke test:
+
+- Started `roscore`.
+- Started `perception_degradation_node.py` with nonzero noise and `false_positive_prob=1.0`.
+- Published synthetic `/gazebo/model_states` containing `person1_0.5_0.5_1.8` and `dynamic_box_3_0.4_0.3_1.0`.
+- Published synthetic `/CERLAB/quadcopter/odom`.
+- Confirmed `/perception_degradation/degraded_obstacles` contained two degraded real obstacles and one false-positive obstacle.
+- Confirmed CSV rows were written to `stage3_degraded_obstacles.csv`.
+- Confirmed `/perception_degradation/degraded_obstacle_markers` publishes RViz cube and radius sphere markers.
+
+Observed sample result:
+
+- `raw_obstacle_count=2`
+- `dropped_obstacle_count=0`
+- `false_positive_count=1`
+- nonzero position and velocity perturbations under configured noise
+
+## Boundary
+
+Stage 3 does not modify Intent-MPC planner behavior. The degraded stream is ready for Stage 4 uncertainty representation and Stage 5 planner integration.

--- a/perception_degradation/CMakeLists.txt
+++ b/perception_degradation/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(perception_degradation)
+
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+  std_msgs
+  geometry_msgs
+  gazebo_msgs
+  nav_msgs
+  visualization_msgs
+  message_generation
+)
+
+add_message_files(
+  FILES
+  DegradedObstacle.msg
+  DegradedObstacleArray.msg
+)
+
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+  geometry_msgs
+)
+
+catkin_package(
+  CATKIN_DEPENDS
+  rospy
+  std_msgs
+  geometry_msgs
+  gazebo_msgs
+  nav_msgs
+  visualization_msgs
+  message_runtime
+)
+
+catkin_install_python(PROGRAMS
+  scripts/perception_degradation_node.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY
+  config
+  launch
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/perception_degradation/config/stage3_default.yaml
+++ b/perception_degradation/config/stage3_default.yaml
@@ -1,0 +1,32 @@
+input_model_states_topic: "/gazebo/model_states"
+odom_topic: "/CERLAB/quadcopter/odom"
+degraded_obstacles_topic: "/perception_degradation/degraded_obstacles"
+marker_topic: "/perception_degradation/degraded_obstacle_markers"
+frame_id: "map"
+
+target_prefixes: ["person", "dynamic_box", "dynamic_cylinder"]
+source_modalities: "pseudo_multimodal_degraded"
+publish_rate: 10.0
+
+position_noise_std: 0.0
+velocity_noise_std: 0.0
+delay_ms: 0.0
+dropout_prob: 0.0
+false_positive_prob: 0.0
+confidence_noise: 0.0
+random_seed: 0
+base_confidence: 1.0
+min_confidence: 0.0
+max_confidence: 1.0
+
+false_positive_size: [0.5, 0.5, 1.8]
+false_positive_velocity_std: 0.2
+false_positive_radius_around_uav: 6.0
+false_positive_z_range: [0.6, 1.8]
+world_x_range: [-8.0, 8.0]
+world_y_range: [-8.0, 8.0]
+max_false_positives_per_tick: 1
+
+write_csv: true
+output_dir: ""
+output_csv: "stage3_degraded_obstacles.csv"

--- a/perception_degradation/launch/run_degradation.launch
+++ b/perception_degradation/launch/run_degradation.launch
@@ -1,0 +1,22 @@
+<launch>
+  <arg name="output_dir" default="$(env HOME)/catkin_ws/experiment_logs" />
+  <arg name="position_noise_std" default="0.0" />
+  <arg name="velocity_noise_std" default="0.0" />
+  <arg name="delay_ms" default="0.0" />
+  <arg name="dropout_prob" default="0.0" />
+  <arg name="false_positive_prob" default="0.0" />
+  <arg name="confidence_noise" default="0.0" />
+  <arg name="random_seed" default="0" />
+
+  <node pkg="perception_degradation" type="perception_degradation_node.py" name="perception_degradation_node" output="screen">
+    <rosparam file="$(find perception_degradation)/config/stage3_default.yaml" />
+    <param name="output_dir" value="$(arg output_dir)" />
+    <param name="position_noise_std" value="$(arg position_noise_std)" />
+    <param name="velocity_noise_std" value="$(arg velocity_noise_std)" />
+    <param name="delay_ms" value="$(arg delay_ms)" />
+    <param name="dropout_prob" value="$(arg dropout_prob)" />
+    <param name="false_positive_prob" value="$(arg false_positive_prob)" />
+    <param name="confidence_noise" value="$(arg confidence_noise)" />
+    <param name="random_seed" value="$(arg random_seed)" />
+  </node>
+</launch>

--- a/perception_degradation/launch/run_degradation_with_recorder.launch
+++ b/perception_degradation/launch/run_degradation_with_recorder.launch
@@ -1,0 +1,36 @@
+<launch>
+  <arg name="scenario_name" default="generated_env" />
+  <arg name="method_name" default="intent_mpc_baseline_observed_degradation" />
+  <arg name="output_dir" default="$(env HOME)/catkin_ws/experiment_logs" />
+  <arg name="position_noise_std" default="0.1" />
+  <arg name="velocity_noise_std" default="0.2" />
+  <arg name="delay_ms" default="100.0" />
+  <arg name="dropout_prob" default="0.1" />
+  <arg name="false_positive_prob" default="0.05" />
+  <arg name="confidence_noise" default="0.1" />
+  <arg name="random_seed" default="1" />
+
+  <include file="$(find perception_degradation)/launch/run_degradation.launch">
+    <arg name="output_dir" value="$(arg output_dir)" />
+    <arg name="position_noise_std" value="$(arg position_noise_std)" />
+    <arg name="velocity_noise_std" value="$(arg velocity_noise_std)" />
+    <arg name="delay_ms" value="$(arg delay_ms)" />
+    <arg name="dropout_prob" value="$(arg dropout_prob)" />
+    <arg name="false_positive_prob" value="$(arg false_positive_prob)" />
+    <arg name="confidence_noise" value="$(arg confidence_noise)" />
+    <arg name="random_seed" value="$(arg random_seed)" />
+  </include>
+
+  <include file="$(find experiment_tools)/launch/record_baseline.launch">
+    <arg name="scenario_name" value="$(arg scenario_name)" />
+    <arg name="method_name" value="$(arg method_name)" />
+    <arg name="output_dir" value="$(arg output_dir)" />
+    <arg name="position_noise_std" value="$(arg position_noise_std)" />
+    <arg name="velocity_noise_std" value="$(arg velocity_noise_std)" />
+    <arg name="delay_ms" value="$(arg delay_ms)" />
+    <arg name="dropout_prob" value="$(arg dropout_prob)" />
+    <arg name="false_positive_prob" value="$(arg false_positive_prob)" />
+    <arg name="confidence_noise" value="$(arg confidence_noise)" />
+    <arg name="random_seed" value="$(arg random_seed)" />
+  </include>
+</launch>

--- a/perception_degradation/msg/DegradedObstacle.msg
+++ b/perception_degradation/msg/DegradedObstacle.msg
@@ -1,0 +1,13 @@
+std_msgs/Header header
+uint32 id
+string label
+geometry_msgs/Point position
+geometry_msgs/Vector3 velocity
+geometry_msgs/Vector3 size
+float64 radius
+float64 confidence
+float64 position_noise_std
+float64 velocity_noise_std
+float64 delay_ms
+bool is_false_positive
+string source_modalities

--- a/perception_degradation/msg/DegradedObstacleArray.msg
+++ b/perception_degradation/msg/DegradedObstacleArray.msg
@@ -1,0 +1,5 @@
+std_msgs/Header header
+DegradedObstacle[] obstacles
+uint32 raw_obstacle_count
+uint32 dropped_obstacle_count
+uint32 false_positive_count

--- a/perception_degradation/package.xml
+++ b/perception_degradation/package.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>perception_degradation</name>
+  <version>0.1.0</version>
+  <description>Configurable perception degradation node for multimodal UAV obstacle experiments.</description>
+  <maintainer email="zsz15964443357@users.noreply.github.com">zsz15964443357-lab</maintainer>
+  <license>MIT</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>gazebo_msgs</build_depend>
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>visualization_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
+
+  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
+
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>gazebo_msgs</exec_depend>
+  <exec_depend>nav_msgs</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+
+  <export>
+  </export>
+</package>

--- a/perception_degradation/scripts/perception_degradation_node.py
+++ b/perception_degradation/scripts/perception_degradation_node.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+import csv
+import math
+import os
+import random
+import re
+from collections import deque
+
+import rospy
+from gazebo_msgs.msg import ModelStates
+from geometry_msgs.msg import Point, Vector3
+from nav_msgs.msg import Odometry
+from visualization_msgs.msg import Marker, MarkerArray
+
+from perception_degradation.msg import DegradedObstacle, DegradedObstacleArray
+
+
+FLOAT_RE = re.compile(r"[-+]?(?:\d*\.\d+|\d+)")
+
+
+def as_float(value, default=0.0):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def as_int(value, default=0):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def as_bool(value, default=False):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    if value is None:
+        return default
+    return bool(value)
+
+
+def as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    return [value]
+
+
+def clamp(value, low, high):
+    return max(low, min(high, value))
+
+
+def finite(values):
+    return all(math.isfinite(item) for item in values)
+
+
+def vector_norm(values):
+    return math.sqrt(sum(item * item for item in values))
+
+
+class RawObstacle:
+    def __init__(self, obstacle_id, label, position, velocity, size):
+        self.id = obstacle_id
+        self.label = label
+        self.position = position
+        self.velocity = velocity
+        self.size = size
+
+
+class PerceptionDegradationNode:
+    def __init__(self):
+        self.input_model_states_topic = rospy.get_param("~input_model_states_topic", "/gazebo/model_states")
+        self.odom_topic = rospy.get_param("~odom_topic", "/CERLAB/quadcopter/odom")
+        self.degraded_obstacles_topic = rospy.get_param("~degraded_obstacles_topic", "/perception_degradation/degraded_obstacles")
+        self.marker_topic = rospy.get_param("~marker_topic", "/perception_degradation/degraded_obstacle_markers")
+        self.frame_id = rospy.get_param("~frame_id", "map")
+
+        self.target_prefixes = [str(item) for item in as_list(rospy.get_param("~target_prefixes", ["person", "dynamic_box", "dynamic_cylinder"]))]
+        self.source_modalities = rospy.get_param("~source_modalities", "pseudo_multimodal_degraded")
+        self.publish_rate = max(as_float(rospy.get_param("~publish_rate", 10.0)), 0.1)
+
+        self.position_noise_std = max(as_float(rospy.get_param("~position_noise_std", 0.0)), 0.0)
+        self.velocity_noise_std = max(as_float(rospy.get_param("~velocity_noise_std", 0.0)), 0.0)
+        self.delay_ms = max(as_float(rospy.get_param("~delay_ms", 0.0)), 0.0)
+        self.dropout_prob = clamp(as_float(rospy.get_param("~dropout_prob", 0.0)), 0.0, 1.0)
+        self.false_positive_prob = clamp(as_float(rospy.get_param("~false_positive_prob", 0.0)), 0.0, 1.0)
+        self.confidence_noise = max(as_float(rospy.get_param("~confidence_noise", 0.0)), 0.0)
+        self.random_seed = as_int(rospy.get_param("~random_seed", 0), 0)
+        self.base_confidence = as_float(rospy.get_param("~base_confidence", 1.0), 1.0)
+        self.min_confidence = as_float(rospy.get_param("~min_confidence", 0.0), 0.0)
+        self.max_confidence = as_float(rospy.get_param("~max_confidence", 1.0), 1.0)
+
+        self.false_positive_size = self.float_list(rospy.get_param("~false_positive_size", [0.5, 0.5, 1.8]), [0.5, 0.5, 1.8])
+        self.false_positive_velocity_std = max(as_float(rospy.get_param("~false_positive_velocity_std", 0.2)), 0.0)
+        self.false_positive_radius_around_uav = max(as_float(rospy.get_param("~false_positive_radius_around_uav", 6.0)), 0.1)
+        self.false_positive_z_range = self.float_list(rospy.get_param("~false_positive_z_range", [0.6, 1.8]), [0.6, 1.8])
+        self.world_x_range = self.float_list(rospy.get_param("~world_x_range", [-8.0, 8.0]), [-8.0, 8.0])
+        self.world_y_range = self.float_list(rospy.get_param("~world_y_range", [-8.0, 8.0]), [-8.0, 8.0])
+        self.max_false_positives_per_tick = max(as_int(rospy.get_param("~max_false_positives_per_tick", 1), 1), 0)
+
+        self.write_csv = as_bool(rospy.get_param("~write_csv", True), True)
+        output_dir = rospy.get_param("~output_dir", "")
+        if not output_dir:
+            output_dir = os.path.expanduser("~/catkin_ws/experiment_logs")
+        self.output_dir = os.path.abspath(os.path.expanduser(output_dir))
+        self.output_csv = self.resolve_path(rospy.get_param("~output_csv", "stage3_degraded_obstacles.csv"))
+
+        self.rng = random.Random(self.random_seed)
+        self.name_to_id = {}
+        self.next_id = 1
+        self.snapshots = deque()
+        self.current_odom_position = None
+
+        self.obstacle_pub = rospy.Publisher(self.degraded_obstacles_topic, DegradedObstacleArray, queue_size=10)
+        self.marker_pub = rospy.Publisher(self.marker_topic, MarkerArray, queue_size=10)
+        self.model_sub = rospy.Subscriber(self.input_model_states_topic, ModelStates, self.model_states_cb, queue_size=10)
+        self.odom_sub = rospy.Subscriber(self.odom_topic, Odometry, self.odom_cb, queue_size=20)
+        self.publish_timer = rospy.Timer(rospy.Duration(1.0 / self.publish_rate), self.publish_timer_cb)
+
+        if self.write_csv:
+            os.makedirs(self.output_dir, exist_ok=True)
+
+        rospy.loginfo(
+            "Perception degradation started: pos_noise=%.3f vel_noise=%.3f delay_ms=%.1f dropout=%.3f false_positive=%.3f output=%s",
+            self.position_noise_std,
+            self.velocity_noise_std,
+            self.delay_ms,
+            self.dropout_prob,
+            self.false_positive_prob,
+            self.degraded_obstacles_topic,
+        )
+
+    @staticmethod
+    def float_list(value, default):
+        items = [as_float(item, math.nan) for item in as_list(value)]
+        if len(items) < len(default) or not finite(items[: len(default)]):
+            return list(default)
+        return items[: len(default)]
+
+    def resolve_path(self, configured_path):
+        path = os.path.expanduser(str(configured_path or "stage3_degraded_obstacles.csv"))
+        if os.path.isabs(path):
+            return path
+        return os.path.join(self.output_dir, path)
+
+    def odom_cb(self, msg):
+        pos = [msg.pose.pose.position.x, msg.pose.pose.position.y, msg.pose.pose.position.z]
+        if finite(pos):
+            self.current_odom_position = pos
+
+    def model_states_cb(self, msg):
+        stamp = rospy.Time.now()
+        raw_obstacles = []
+        for name, pose, twist in zip(msg.name, msg.pose, msg.twist):
+            if not self.is_target_obstacle(name):
+                continue
+            size = self.parse_obstacle_size(name)
+            position = [pose.position.x, pose.position.y, pose.position.z]
+            if name.startswith("person"):
+                position[2] += size[2] * 0.5
+            velocity = [twist.linear.x, twist.linear.y, twist.linear.z]
+            if not finite(position) or not finite(velocity) or not finite(size):
+                continue
+            obstacle_id = self.stable_id(name)
+            raw_obstacles.append(RawObstacle(obstacle_id, name, position, velocity, size))
+
+        self.snapshots.append((stamp, raw_obstacles))
+        self.trim_snapshots(stamp)
+
+    def trim_snapshots(self, now):
+        delay_sec = self.delay_ms / 1000.0
+        keep_after = now - rospy.Duration(delay_sec + 2.0)
+        while len(self.snapshots) > 1 and self.snapshots[0][0] < keep_after:
+            self.snapshots.popleft()
+
+    def stable_id(self, name):
+        if name not in self.name_to_id:
+            self.name_to_id[name] = self.next_id
+            self.next_id += 1
+        return self.name_to_id[name]
+
+    def is_target_obstacle(self, name):
+        return any(name.startswith(prefix) for prefix in self.target_prefixes)
+
+    @staticmethod
+    def parse_obstacle_size(name):
+        values = [float(item) for item in FLOAT_RE.findall(name)]
+        if len(values) >= 3:
+            return values[-3:]
+        return [0.5, 0.5, 1.8] if name.startswith("person") else [0.5, 0.5, 1.0]
+
+    @staticmethod
+    def radius_from_size(size):
+        return 0.5 * vector_norm(size)
+
+    def delayed_snapshot(self, now):
+        if not self.snapshots:
+            return []
+        target_time = now - rospy.Duration(self.delay_ms / 1000.0)
+        selected = self.snapshots[0][1]
+        for stamp, obstacles in self.snapshots:
+            if stamp <= target_time:
+                selected = obstacles
+            else:
+                break
+        return selected
+
+    def publish_timer_cb(self, _event):
+        now = rospy.Time.now()
+        raw_obstacles = self.delayed_snapshot(now)
+        degraded = []
+        dropped_count = 0
+
+        for obstacle in raw_obstacles:
+            if self.rng.random() < self.dropout_prob:
+                dropped_count += 1
+                continue
+            degraded.append(self.degrade_obstacle(obstacle, now, is_false_positive=False))
+
+        false_positives = self.generate_false_positives(now)
+        degraded.extend(false_positives)
+
+        msg = DegradedObstacleArray()
+        msg.header.stamp = now
+        msg.header.frame_id = self.frame_id
+        msg.obstacles = degraded
+        msg.raw_obstacle_count = len(raw_obstacles)
+        msg.dropped_obstacle_count = dropped_count
+        msg.false_positive_count = len(false_positives)
+        self.obstacle_pub.publish(msg)
+        self.marker_pub.publish(self.build_markers(msg))
+
+        if self.write_csv:
+            self.write_csv_rows(msg)
+
+    def degrade_obstacle(self, obstacle, stamp, is_false_positive):
+        pos = [
+            obstacle.position[0] + self.rng.gauss(0.0, self.position_noise_std),
+            obstacle.position[1] + self.rng.gauss(0.0, self.position_noise_std),
+            obstacle.position[2] + self.rng.gauss(0.0, self.position_noise_std),
+        ]
+        vel = [
+            obstacle.velocity[0] + self.rng.gauss(0.0, self.velocity_noise_std),
+            obstacle.velocity[1] + self.rng.gauss(0.0, self.velocity_noise_std),
+            obstacle.velocity[2] + self.rng.gauss(0.0, self.velocity_noise_std),
+        ]
+        confidence = clamp(
+            self.base_confidence + self.rng.gauss(0.0, self.confidence_noise),
+            self.min_confidence,
+            self.max_confidence,
+        )
+
+        msg = DegradedObstacle()
+        msg.header.stamp = stamp
+        msg.header.frame_id = self.frame_id
+        msg.id = obstacle.id
+        msg.label = obstacle.label
+        msg.position = Point(*pos)
+        msg.velocity = Vector3(*vel)
+        msg.size = Vector3(*obstacle.size)
+        msg.radius = self.radius_from_size(obstacle.size)
+        msg.confidence = confidence
+        msg.position_noise_std = self.position_noise_std
+        msg.velocity_noise_std = self.velocity_noise_std
+        msg.delay_ms = self.delay_ms
+        msg.is_false_positive = is_false_positive
+        msg.source_modalities = self.source_modalities
+        return msg
+
+    def generate_false_positives(self, stamp):
+        false_positives = []
+        for _idx in range(self.max_false_positives_per_tick):
+            if self.rng.random() >= self.false_positive_prob:
+                continue
+            raw = self.false_positive_obstacle()
+            false_positives.append(self.degrade_obstacle(raw, stamp, is_false_positive=True))
+        return false_positives
+
+    def false_positive_obstacle(self):
+        if self.current_odom_position is not None:
+            angle = self.rng.uniform(-math.pi, math.pi)
+            radius = self.rng.uniform(0.5, self.false_positive_radius_around_uav)
+            x = self.current_odom_position[0] + radius * math.cos(angle)
+            y = self.current_odom_position[1] + radius * math.sin(angle)
+        else:
+            x = self.rng.uniform(self.world_x_range[0], self.world_x_range[1])
+            y = self.rng.uniform(self.world_y_range[0], self.world_y_range[1])
+        z = self.rng.uniform(self.false_positive_z_range[0], self.false_positive_z_range[1])
+        velocity = [
+            self.rng.gauss(0.0, self.false_positive_velocity_std),
+            self.rng.gauss(0.0, self.false_positive_velocity_std),
+            0.0,
+        ]
+        obstacle_id = self.stable_id("false_positive")
+        return RawObstacle(obstacle_id, "false_positive", [x, y, z], velocity, list(self.false_positive_size))
+
+    def build_markers(self, obstacle_array):
+        markers = MarkerArray()
+        for idx, obstacle in enumerate(obstacle_array.obstacles):
+            box = Marker()
+            box.header = obstacle_array.header
+            box.ns = "degraded_obstacles"
+            box.id = idx * 2
+            box.type = Marker.CUBE
+            box.action = Marker.ADD
+            box.pose.position = obstacle.position
+            box.pose.orientation.w = 1.0
+            box.scale.x = max(obstacle.size.x, 0.05)
+            box.scale.y = max(obstacle.size.y, 0.05)
+            box.scale.z = max(obstacle.size.z, 0.05)
+            box.color.a = 0.35
+            if obstacle.is_false_positive:
+                box.color.r = 1.0
+                box.color.g = 0.2
+                box.color.b = 0.1
+            else:
+                box.color.r = 0.1
+                box.color.g = 0.45
+                box.color.b = 1.0
+            box.lifetime = rospy.Duration(0.5)
+            markers.markers.append(box)
+
+            sphere = Marker()
+            sphere.header = obstacle_array.header
+            sphere.ns = "degraded_radius"
+            sphere.id = idx * 2 + 1
+            sphere.type = Marker.SPHERE
+            sphere.action = Marker.ADD
+            sphere.pose.position = obstacle.position
+            sphere.pose.orientation.w = 1.0
+            diameter = max(2.0 * obstacle.radius, 0.05)
+            sphere.scale.x = diameter
+            sphere.scale.y = diameter
+            sphere.scale.z = diameter
+            sphere.color.a = 0.12
+            sphere.color.r = 1.0 - obstacle.confidence
+            sphere.color.g = obstacle.confidence
+            sphere.color.b = 0.0
+            sphere.lifetime = rospy.Duration(0.5)
+            markers.markers.append(sphere)
+        return markers
+
+    @staticmethod
+    def csv_header():
+        return [
+            "stamp",
+            "obstacle_id",
+            "label",
+            "x",
+            "y",
+            "z",
+            "vx",
+            "vy",
+            "vz",
+            "size_x",
+            "size_y",
+            "size_z",
+            "radius",
+            "confidence",
+            "position_noise_std",
+            "velocity_noise_std",
+            "delay_ms",
+            "dropout_prob",
+            "false_positive_prob",
+            "confidence_noise",
+            "random_seed",
+            "is_false_positive",
+            "source_modalities",
+            "raw_obstacle_count",
+            "dropped_obstacle_count",
+            "false_positive_count",
+        ]
+
+    def write_csv_rows(self, msg):
+        rows = []
+        for obstacle in msg.obstacles:
+            rows.append(
+                {
+                    "stamp": msg.header.stamp.to_sec(),
+                    "obstacle_id": obstacle.id,
+                    "label": obstacle.label,
+                    "x": obstacle.position.x,
+                    "y": obstacle.position.y,
+                    "z": obstacle.position.z,
+                    "vx": obstacle.velocity.x,
+                    "vy": obstacle.velocity.y,
+                    "vz": obstacle.velocity.z,
+                    "size_x": obstacle.size.x,
+                    "size_y": obstacle.size.y,
+                    "size_z": obstacle.size.z,
+                    "radius": obstacle.radius,
+                    "confidence": obstacle.confidence,
+                    "position_noise_std": self.position_noise_std,
+                    "velocity_noise_std": self.velocity_noise_std,
+                    "delay_ms": self.delay_ms,
+                    "dropout_prob": self.dropout_prob,
+                    "false_positive_prob": self.false_positive_prob,
+                    "confidence_noise": self.confidence_noise,
+                    "random_seed": self.random_seed,
+                    "is_false_positive": int(obstacle.is_false_positive),
+                    "source_modalities": obstacle.source_modalities,
+                    "raw_obstacle_count": msg.raw_obstacle_count,
+                    "dropped_obstacle_count": msg.dropped_obstacle_count,
+                    "false_positive_count": msg.false_positive_count,
+                }
+            )
+        if not rows:
+            return
+        should_write_header = not os.path.exists(self.output_csv) or os.path.getsize(self.output_csv) == 0
+        with open(self.output_csv, "a", newline="") as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=self.csv_header())
+            if should_write_header:
+                writer.writeheader()
+            writer.writerows(rows)
+
+
+def main():
+    rospy.init_node("perception_degradation_node")
+    PerceptionDegradationNode()
+    rospy.spin()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Goal

Complete Stage 3 perception degradation support for the UAV multimodal uncertainty research plan.

## Changes

- Added `perception_degradation` ROS package.
- Added `DegradedObstacle` and `DegradedObstacleArray` messages.
- Added configurable `perception_degradation_node.py`.
- Supports position noise, velocity noise, delay, dropout, false positives, confidence noise, and random seed.
- Publishes degraded obstacle topic and RViz markers.
- Writes per-obstacle degradation CSV samples.
- Added Stage 3 prompt, design, README, final report, and updated project workflow status.
- Added a small `.gitignore` for Python/cache/log output hygiene.

## Validation

- `python3 -m py_compile perception_degradation/scripts/perception_degradation_node.py` passed.
- Docker ROS Noetic `catkin_make` passed; both messages generated successfully.
- `roslaunch perception_degradation run_degradation.launch --nodes` resolves `/perception_degradation_node`.
- ROS smoke test published synthetic `/gazebo/model_states` and `/CERLAB/quadcopter/odom`; confirmed degraded obstacle output with two real obstacles plus one false positive and CSV rows.
- Marker smoke test confirmed `/perception_degradation/degraded_obstacle_markers` publishes cube and radius sphere markers.

## Notes

This stage intentionally does not feed degraded obstacles into MPC. The official demo still uses the original detector/planner path. Planner consumption remains reserved for Stage 5.

Closes #9.
Closes #10.
