### PR TITLE
Stage 5: safety local planner modes

### DIFF
--- a/autonomous_flight/CMakeLists.txt
+++ b/autonomous_flight/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(catkin REQUIRED COMPONENTS
   tracking_controller
   time_optimizer
   dynamic_predictor
+  multimodal_uncertainty
 )
 
 ## System dependencies are found with CMake's conventions

--- a/autonomous_flight/cfg/mpc_navigation/flight_base.yaml
+++ b/autonomous_flight/cfg/mpc_navigation/flight_base.yaml
@@ -14,3 +14,14 @@ use_predefined_goal: true
 predefined_goal_directory: "/cfg/mpc_navigation/ref_trajectory.txt"
 execute_path_times: 10 # how many times to repeat the trajectory 
 
+# Stage 5 dynamic obstacle planning mode:
+# - original: official Intent-MPC behavior
+# - fixed_margin: inflate dynamic obstacle dimensions by fixed_safety_margin before MPC
+# - uncertainty_aware: use /multimodal_uncertainty/uncertainty_obstacles effective_radius when fresh
+dynamic_obstacle_mode: "original"
+fixed_safety_margin: 0.0
+uncertainty_obstacles_topic: "/multimodal_uncertainty/uncertainty_obstacles"
+uncertainty_size_mode: "scale_radius" # scale_radius or add_margin
+uncertainty_max_age: 0.5
+uncertainty_association_distance: 2.0
+uncertainty_fallback_to_original: true

--- a/autonomous_flight/include/autonomous_flight/mpcNavigation.cpp
+++ b/autonomous_flight/include/autonomous_flight/mpcNavigation.cpp
@@ -5,6 +5,10 @@
 */
 #include <autonomous_flight/mpcNavigation.h>
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 namespace AutoFlight{
 	mpcNavigation::mpcNavigation(const ros::NodeHandle& nh) : flightBase(nh){
 		this->initParam();
@@ -120,7 +124,48 @@ namespace AutoFlight{
 		else{
 			cout << "[AutoFlight]: Execute path number of times is set to: " << this->repeatPathNum_ << "." << endl;
 		}	
-		
+
+		if (not this->nh_.getParam("autonomous_flight/dynamic_obstacle_mode", this->dynamicObstacleMode_)){
+			this->dynamicObstacleMode_ = "original";
+			cout << "[AutoFlight]: No dynamic obstacle mode param found. Use default: original." << endl;
+		}
+		if (this->dynamicObstacleMode_ != "original" and this->dynamicObstacleMode_ != "fixed_margin" and this->dynamicObstacleMode_ != "uncertainty_aware"){
+			cout << "[AutoFlight]: Unknown dynamic obstacle mode " << this->dynamicObstacleMode_ << ". Use original." << endl;
+			this->dynamicObstacleMode_ = "original";
+		}
+		cout << "[AutoFlight]: Dynamic obstacle mode is set to: " << this->dynamicObstacleMode_ << "." << endl;
+
+		if (not this->nh_.getParam("autonomous_flight/fixed_safety_margin", this->fixedSafetyMargin_)){
+			this->fixedSafetyMargin_ = 0.0;
+		}
+		this->fixedSafetyMargin_ = std::max(0.0, this->fixedSafetyMargin_);
+		cout << "[AutoFlight]: Fixed dynamic obstacle safety margin: " << this->fixedSafetyMargin_ << "m." << endl;
+
+		if (not this->nh_.getParam("autonomous_flight/uncertainty_obstacles_topic", this->uncertaintyObstaclesTopic_)){
+			this->uncertaintyObstaclesTopic_ = "/multimodal_uncertainty/uncertainty_obstacles";
+		}
+		if (not this->nh_.getParam("autonomous_flight/uncertainty_size_mode", this->uncertaintySizeMode_)){
+			this->uncertaintySizeMode_ = "scale_radius";
+		}
+		if (this->uncertaintySizeMode_ != "scale_radius" and this->uncertaintySizeMode_ != "add_margin"){
+			cout << "[AutoFlight]: Unknown uncertainty size mode " << this->uncertaintySizeMode_ << ". Use scale_radius." << endl;
+			this->uncertaintySizeMode_ = "scale_radius";
+		}
+		if (not this->nh_.getParam("autonomous_flight/uncertainty_max_age", this->uncertaintyMaxAge_)){
+			this->uncertaintyMaxAge_ = 0.5;
+		}
+		this->uncertaintyMaxAge_ = std::max(0.0, this->uncertaintyMaxAge_);
+		if (not this->nh_.getParam("autonomous_flight/uncertainty_association_distance", this->uncertaintyAssociationDistance_)){
+			this->uncertaintyAssociationDistance_ = 2.0;
+		}
+		this->uncertaintyAssociationDistance_ = std::max(0.0, this->uncertaintyAssociationDistance_);
+		if (not this->nh_.getParam("autonomous_flight/uncertainty_fallback_to_original", this->uncertaintyFallbackToOriginal_)){
+			this->uncertaintyFallbackToOriginal_ = true;
+		}
+		cout << "[AutoFlight]: Uncertainty obstacle topic: " << this->uncertaintyObstaclesTopic_
+			 << ", size mode: " << this->uncertaintySizeMode_
+			 << ", max age: " << this->uncertaintyMaxAge_
+			 << "s, association distance: " << this->uncertaintyAssociationDistance_ << "m." << endl;
 
 	}
 
@@ -175,6 +220,10 @@ namespace AutoFlight{
 	void mpcNavigation::registerCallback(){
 		this->mpcWorker_ = std::thread(&mpcNavigation::mpcCB, this);
 		this->mpcWorker_.detach();
+
+		if (this->isUncertaintyAwareMode()){
+			this->uncertaintyObstacleSub_ = this->nh_.subscribe(this->uncertaintyObstaclesTopic_, 10, &mpcNavigation::uncertaintyObstaclesCB, this);
+		}
 
 		// collision check callback
 		this->replanCheckTimer_ = this->nh_.createTimer(ros::Duration(0.01), &mpcNavigation::replanCheckCB, this);
@@ -295,18 +344,12 @@ namespace AutoFlight{
 						std::vector<std::vector<std::vector<Eigen::Vector3d>>> predPos, predSize;
 						std::vector<Eigen::VectorXd> intentProb;
 						this->predictor_->getPrediction(predPos, predSize, intentProb);
+						this->applyPlannerModeToPredictions(predPos, predSize);
 						this->mpc_->updatePredObstacles(predPos, predSize, intentProb);
 					}
 					else{
 						std::vector<Eigen::Vector3d> obstaclesPos, obstaclesVel, obstaclesSize;
-						if (this->useFakeDetector_){
-							Eigen::Vector3d robotSize;
-							this->map_->getRobotSize(robotSize);
-							this->getDynamicObstacles(obstaclesPos, obstaclesVel, obstaclesSize, robotSize);
-						}
-						else{ 
-							this->map_->getDynamicObstacles(obstaclesPos, obstaclesVel, obstaclesSize);
-						}
+						this->getPlannerDynamicObstacles(obstaclesPos, obstaclesVel, obstaclesSize);
 						this->mpc_->updateDynamicObstacles(obstaclesPos, obstaclesVel, obstaclesSize);
 					}
 
@@ -658,14 +701,7 @@ namespace AutoFlight{
 
 		if (trajectoryReady){
 			std::vector<Eigen::Vector3d> obstaclesPos, obstaclesVel, obstaclesSize;
-			if (this->useFakeDetector_){
-				Eigen::Vector3d robotSize;
-				this->map_->getRobotSize(robotSize);
-				this->getDynamicObstacles(obstaclesPos, obstaclesVel, obstaclesSize, robotSize);
-			}
-			else{ 
-				this->map_->getDynamicObstacles(obstaclesPos, obstaclesVel, obstaclesSize);
-			}
+			this->getPlannerDynamicObstacles(obstaclesPos, obstaclesVel, obstaclesSize);
 			double dt = this->mpc_->getTs();
 			ros::Time currTime = ros::Time::now();
 			double startTime = std::min(1.0, (currTime-this->trajStartTime_).toSec());
@@ -699,6 +735,183 @@ namespace AutoFlight{
 			obstaclesVel.push_back(vel);
 			obstaclesSize.push_back(size);
 		}
+	}
+
+	bool mpcNavigation::isFixedMarginMode(){
+		return this->dynamicObstacleMode_ == "fixed_margin";
+	}
+
+	bool mpcNavigation::isUncertaintyAwareMode(){
+		return this->dynamicObstacleMode_ == "uncertainty_aware";
+	}
+
+	void mpcNavigation::uncertaintyObstaclesCB(const multimodal_uncertainty::UncertaintyObstacleArrayConstPtr& msg){
+		std::lock_guard<std::mutex> lock(this->uncertaintyObstacleMutex_);
+		this->latestUncertaintyObstacles_ = *msg;
+		this->lastUncertaintyObstacleTime_ = ros::Time::now();
+		this->uncertaintyObstaclesReady_ = true;
+	}
+
+	bool mpcNavigation::getLatestUncertaintyObstacles(multimodal_uncertainty::UncertaintyObstacleArray& msg){
+		std::lock_guard<std::mutex> lock(this->uncertaintyObstacleMutex_);
+		if (not this->uncertaintyObstaclesReady_){
+			return false;
+		}
+		double age = (ros::Time::now() - this->lastUncertaintyObstacleTime_).toSec();
+		if (age > this->uncertaintyMaxAge_){
+			ROS_WARN_THROTTLE(1.0, "[AutoFlight]: Uncertainty obstacle message is stale: %.3fs.", age);
+			return false;
+		}
+		msg = this->latestUncertaintyObstacles_;
+		return true;
+	}
+
+	bool mpcNavigation::getUncertaintyDynamicObstacles(std::vector<Eigen::Vector3d>& obstaclesPos, std::vector<Eigen::Vector3d>& obstaclesVel, std::vector<Eigen::Vector3d>& obstaclesSize){
+		multimodal_uncertainty::UncertaintyObstacleArray msg;
+		if (not this->getLatestUncertaintyObstacles(msg)){
+			return false;
+		}
+		obstaclesPos.clear();
+		obstaclesVel.clear();
+		obstaclesSize.clear();
+		for (const auto& ob : msg.obstacles){
+			Eigen::Vector3d pos(ob.position.x, ob.position.y, ob.position.z);
+			Eigen::Vector3d vel(ob.velocity.x, ob.velocity.y, ob.velocity.z);
+			Eigen::Vector3d size(ob.size.x, ob.size.y, ob.size.z);
+			if (not (std::isfinite(pos(0)) and std::isfinite(pos(1)) and std::isfinite(pos(2)) and
+					 std::isfinite(vel(0)) and std::isfinite(vel(1)) and std::isfinite(vel(2)) and
+					 std::isfinite(size(0)) and std::isfinite(size(1)) and std::isfinite(size(2)))){
+				continue;
+			}
+			size = this->inflateSizeByEffectiveRadius(size, ob.radius, ob.effective_radius);
+			obstaclesPos.push_back(pos);
+			obstaclesVel.push_back(vel);
+			obstaclesSize.push_back(size);
+		}
+		return true;
+	}
+
+	void mpcNavigation::getPlannerDynamicObstacles(std::vector<Eigen::Vector3d>& obstaclesPos, std::vector<Eigen::Vector3d>& obstaclesVel, std::vector<Eigen::Vector3d>& obstaclesSize){
+		obstaclesPos.clear();
+		obstaclesVel.clear();
+		obstaclesSize.clear();
+		if (this->isUncertaintyAwareMode()){
+			if (this->getUncertaintyDynamicObstacles(obstaclesPos, obstaclesVel, obstaclesSize)){
+				return;
+			}
+			if (not this->uncertaintyFallbackToOriginal_){
+				ROS_WARN_THROTTLE(1.0, "[AutoFlight]: No fresh uncertainty obstacles; planner obstacle set is empty by configuration.");
+				return;
+			}
+		}
+
+		if (this->useFakeDetector_){
+			Eigen::Vector3d robotSize;
+			this->map_->getRobotSize(robotSize);
+			this->getDynamicObstacles(obstaclesPos, obstaclesVel, obstaclesSize, robotSize);
+		}
+		else{
+			this->map_->getDynamicObstacles(obstaclesPos, obstaclesVel, obstaclesSize);
+		}
+		if (this->isFixedMarginMode()){
+			this->inflateCurrentObstacleSizes(obstaclesSize);
+		}
+	}
+
+	void mpcNavigation::inflateCurrentObstacleSizes(std::vector<Eigen::Vector3d>& obstaclesSize){
+		for (auto& size : obstaclesSize){
+			size = this->inflateSizeByFixedMargin(size);
+		}
+	}
+
+	void mpcNavigation::applyPlannerModeToPredictions(std::vector<std::vector<std::vector<Eigen::Vector3d>>>& predPos, std::vector<std::vector<std::vector<Eigen::Vector3d>>>& predSize){
+		if (this->isFixedMarginMode()){
+			this->inflatePredictedObstacleSizes(predSize);
+			return;
+		}
+		if (not this->isUncertaintyAwareMode()){
+			return;
+		}
+		multimodal_uncertainty::UncertaintyObstacleArray uncertaintyMsg;
+		if (not this->getLatestUncertaintyObstacles(uncertaintyMsg)){
+			if (not this->uncertaintyFallbackToOriginal_){
+				predPos.clear();
+				predSize.clear();
+			}
+			return;
+		}
+		for (size_t i=0; i<predPos.size() and i<predSize.size(); ++i){
+			Eigen::Vector3d refPos;
+			bool hasRefPos = false;
+			for (const auto& branch : predPos[i]){
+				if (not branch.empty()){
+					refPos = branch.front();
+					hasRefPos = true;
+					break;
+				}
+			}
+			if (not hasRefPos){
+				continue;
+			}
+			int matchIdx = -1;
+			if (not this->findUncertaintyMatch(refPos, uncertaintyMsg, matchIdx)){
+				continue;
+			}
+			const auto& uncertaintyOb = uncertaintyMsg.obstacles[matchIdx];
+			for (auto& branchSize : predSize[i]){
+				for (auto& size : branchSize){
+					size = this->inflateSizeByEffectiveRadius(size, uncertaintyOb.radius, uncertaintyOb.effective_radius);
+				}
+			}
+		}
+	}
+
+	void mpcNavigation::inflatePredictedObstacleSizes(std::vector<std::vector<std::vector<Eigen::Vector3d>>>& predSize){
+		for (auto& obstacleSize : predSize){
+			for (auto& branchSize : obstacleSize){
+				for (auto& size : branchSize){
+					size = this->inflateSizeByFixedMargin(size);
+				}
+			}
+		}
+	}
+
+	bool mpcNavigation::findUncertaintyMatch(const Eigen::Vector3d& pos, const multimodal_uncertainty::UncertaintyObstacleArray& uncertaintyMsg, int& matchIdx){
+		matchIdx = -1;
+		double bestDist = std::numeric_limits<double>::infinity();
+		for (int i=0; i<int(uncertaintyMsg.obstacles.size()); ++i){
+			const auto& ob = uncertaintyMsg.obstacles[i];
+			Eigen::Vector3d uncertaintyPos(ob.position.x, ob.position.y, ob.position.z);
+			double dist = (pos - uncertaintyPos).norm();
+			if (dist < bestDist){
+				bestDist = dist;
+				matchIdx = i;
+			}
+		}
+		return matchIdx >= 0 and bestDist <= this->uncertaintyAssociationDistance_;
+	}
+
+	Eigen::Vector3d mpcNavigation::inflateSizeByFixedMargin(const Eigen::Vector3d& size){
+		if (this->fixedSafetyMargin_ <= 0.0){
+			return size;
+		}
+		return size + Eigen::Vector3d::Constant(2.0 * this->fixedSafetyMargin_);
+	}
+
+	Eigen::Vector3d mpcNavigation::inflateSizeByEffectiveRadius(const Eigen::Vector3d& size, double radius, double effectiveRadius){
+		if (not std::isfinite(effectiveRadius) or effectiveRadius <= 0.0){
+			return size;
+		}
+		double safeRadius = radius;
+		if (not std::isfinite(safeRadius) or safeRadius <= 1e-3){
+			safeRadius = std::max(0.5 * size.norm(), 1e-3);
+		}
+		if (this->uncertaintySizeMode_ == "add_margin"){
+			double margin = std::max(0.0, effectiveRadius - safeRadius);
+			return size + Eigen::Vector3d::Constant(2.0 * margin);
+		}
+		double scale = std::max(1.0, effectiveRadius / safeRadius);
+		return size * scale;
 	}
 
 	void mpcNavigation::publishGoal(){

--- a/autonomous_flight/include/autonomous_flight/mpcNavigation.h
+++ b/autonomous_flight/include/autonomous_flight/mpcNavigation.h
@@ -17,6 +17,9 @@
 #include <trajectory_planner/piecewiseLinearTraj.h>
 #include <trajectory_planner/bsplineTraj.h>
 #include <trajectory_planner/mpcPlanner.h>
+#include <multimodal_uncertainty/UncertaintyObstacleArray.h>
+
+#include <mutex>
 
 namespace AutoFlight{
 
@@ -41,6 +44,7 @@ namespace AutoFlight{
 		ros::Publisher mpcTrajPub_;
 		ros::Publisher inputTrajPub_;
 		ros::Publisher goalPub_;
+		ros::Subscriber uncertaintyObstacleSub_;
 
 		std::thread mpcWorker_;
 
@@ -58,6 +62,13 @@ namespace AutoFlight{
 		nav_msgs::Path predefinedGoal_;
 		int goalIdx_ = 0;
 		int repeatPathNum_;
+		std::string dynamicObstacleMode_;
+		std::string uncertaintyObstaclesTopic_;
+		std::string uncertaintySizeMode_;
+		double fixedSafetyMargin_;
+		double uncertaintyMaxAge_;
+		double uncertaintyAssociationDistance_;
+		bool uncertaintyFallbackToOriginal_;
 
 		// navigation data
 		bool mpcReplan_ = false;
@@ -81,6 +92,23 @@ namespace AutoFlight{
 		bool firstTimeSave_ = false;
 		bool lastDynamicObstacle_ = false;
 		ros::Time lastDynamicObstacleTime_;
+		std::mutex uncertaintyObstacleMutex_;
+		multimodal_uncertainty::UncertaintyObstacleArray latestUncertaintyObstacles_;
+		bool uncertaintyObstaclesReady_ = false;
+		ros::Time lastUncertaintyObstacleTime_;
+
+		bool isFixedMarginMode();
+		bool isUncertaintyAwareMode();
+		void uncertaintyObstaclesCB(const multimodal_uncertainty::UncertaintyObstacleArrayConstPtr& msg);
+		bool getLatestUncertaintyObstacles(multimodal_uncertainty::UncertaintyObstacleArray& msg);
+		bool getUncertaintyDynamicObstacles(std::vector<Eigen::Vector3d>& obstaclesPos, std::vector<Eigen::Vector3d>& obstaclesVel, std::vector<Eigen::Vector3d>& obstaclesSize);
+		void getPlannerDynamicObstacles(std::vector<Eigen::Vector3d>& obstaclesPos, std::vector<Eigen::Vector3d>& obstaclesVel, std::vector<Eigen::Vector3d>& obstaclesSize);
+		void inflateCurrentObstacleSizes(std::vector<Eigen::Vector3d>& obstaclesSize);
+		void applyPlannerModeToPredictions(std::vector<std::vector<std::vector<Eigen::Vector3d>>>& predPos, std::vector<std::vector<std::vector<Eigen::Vector3d>>>& predSize);
+		void inflatePredictedObstacleSizes(std::vector<std::vector<std::vector<Eigen::Vector3d>>>& predSize);
+		bool findUncertaintyMatch(const Eigen::Vector3d& pos, const multimodal_uncertainty::UncertaintyObstacleArray& uncertaintyMsg, int& matchIdx);
+		Eigen::Vector3d inflateSizeByFixedMargin(const Eigen::Vector3d& size);
+		Eigen::Vector3d inflateSizeByEffectiveRadius(const Eigen::Vector3d& size, double radius, double effectiveRadius);
 		
 	public:
 		mpcNavigation(const ros::NodeHandle& nh);

--- a/autonomous_flight/launch/intent_mpc_demo_fixed_margin.launch
+++ b/autonomous_flight/launch/intent_mpc_demo_fixed_margin.launch
@@ -1,0 +1,18 @@
+<launch>
+	<arg name="fixed_safety_margin" default="0.3" />
+
+	<rosparam file="$(find tracking_controller)/cfg/controller_param.yaml" ns="controller"/>
+	<rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/fake_detector_param.yaml" />
+	<rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/flight_base.yaml" ns="autonomous_flight"/>
+	<rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/planner_param.yaml" />
+	<rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/mapping_param.yaml" ns="/dynamic_map" />
+	<rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/dynamic_detector_param.yaml" ns="/onboard_detector" />
+	<rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/predictor_param.yaml" ns="/dynamic_predictor" />
+
+	<param name="autonomous_flight/dynamic_obstacle_mode" value="fixed_margin" />
+	<param name="autonomous_flight/fixed_safety_margin" value="$(arg fixed_safety_margin)" />
+
+	<node pkg="tracking_controller" type="tracking_controller_node" name="tracking_controller_node" output="screen" />
+	<node pkg="autonomous_flight" type="mpc_navigation_node" name="mpc_navigation_node" output="screen" />
+	<include file="$(find remote_control)/launch/mpc_navigation_fast_rviz.launch" />
+</launch>

--- a/autonomous_flight/launch/intent_mpc_demo_uncertainty.launch
+++ b/autonomous_flight/launch/intent_mpc_demo_uncertainty.launch
@@ -1,0 +1,48 @@
+<launch>
+	<arg name="position_noise_std" default="0.1" />
+	<arg name="velocity_noise_std" default="0.2" />
+	<arg name="delay_ms" default="100.0" />
+	<arg name="dropout_prob" default="0.0" />
+	<arg name="false_positive_prob" default="0.0" />
+	<arg name="confidence_noise" default="0.1" />
+	<arg name="random_seed" default="1" />
+	<arg name="alpha" default="1.0" />
+	<arg name="beta" default="0.5" />
+	<arg name="gamma" default="0.002" />
+	<arg name="delta" default="0.8" />
+	<arg name="output_dir" default="$(env HOME)/catkin_ws/experiment_logs" />
+
+	<rosparam file="$(find tracking_controller)/cfg/controller_param.yaml" ns="controller"/>
+	<rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/fake_detector_param.yaml" />
+	<rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/flight_base.yaml" ns="autonomous_flight"/>
+	<rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/planner_param.yaml" />
+	<rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/mapping_param.yaml" ns="/dynamic_map" />
+	<rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/dynamic_detector_param.yaml" ns="/onboard_detector" />
+	<rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/predictor_param.yaml" ns="/dynamic_predictor" />
+
+	<param name="autonomous_flight/dynamic_obstacle_mode" value="uncertainty_aware" />
+	<param name="autonomous_flight/uncertainty_obstacles_topic" value="/multimodal_uncertainty/uncertainty_obstacles" />
+	<param name="autonomous_flight/uncertainty_size_mode" value="scale_radius" />
+	<param name="autonomous_flight/uncertainty_max_age" value="0.5" />
+	<param name="autonomous_flight/uncertainty_association_distance" value="2.0" />
+	<param name="autonomous_flight/uncertainty_fallback_to_original" value="true" />
+
+	<include file="$(find multimodal_uncertainty)/launch/run_stage4_pipeline.launch">
+		<arg name="output_dir" value="$(arg output_dir)" />
+		<arg name="position_noise_std" value="$(arg position_noise_std)" />
+		<arg name="velocity_noise_std" value="$(arg velocity_noise_std)" />
+		<arg name="delay_ms" value="$(arg delay_ms)" />
+		<arg name="dropout_prob" value="$(arg dropout_prob)" />
+		<arg name="false_positive_prob" value="$(arg false_positive_prob)" />
+		<arg name="confidence_noise" value="$(arg confidence_noise)" />
+		<arg name="random_seed" value="$(arg random_seed)" />
+		<arg name="alpha" value="$(arg alpha)" />
+		<arg name="beta" value="$(arg beta)" />
+		<arg name="gamma" value="$(arg gamma)" />
+		<arg name="delta" value="$(arg delta)" />
+	</include>
+
+	<node pkg="tracking_controller" type="tracking_controller_node" name="tracking_controller_node" output="screen" />
+	<node pkg="autonomous_flight" type="mpc_navigation_node" name="mpc_navigation_node" output="screen" />
+	<include file="$(find remote_control)/launch/mpc_navigation_fast_rviz.launch" />
+</launch>

--- a/autonomous_flight/package.xml
+++ b/autonomous_flight/package.xml
@@ -19,13 +19,16 @@
   <build_depend>map_manager</build_depend>
   <build_depend>tracking_controller</build_depend>
   <build_depend>time_optimizer</build_depend>
+  <build_depend>multimodal_uncertainty</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
+  <build_export_depend>multimodal_uncertainty</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>tracking_controller</exec_depend>
+  <exec_depend>multimodal_uncertainty</exec_depend>
 
   <export>
   </export>

--- a/docs/project_management/github_workflow.md
+++ b/docs/project_management/github_workflow.md
@@ -14,8 +14,8 @@ The `main` branch currently stores the high-level research plan. The reproductio
 - `stage2-experiment-logging`: stage 2 experiment logging package, CSV schema, summary, and plotting scripts.
 - `stage3-perception-degradation`: stage 3 perception degradation node, degraded obstacle messages, RViz markers, and CSV samples.
 - `stage4-multimodal-uncertainty`: stage 4 uncertainty obstacle messages, effective-radius calculation, RViz risk radius markers, and CSV samples.
+- `stage5-safety-local-planner`: stage 5 planner integration for original, fixed-margin, and uncertainty-aware dynamic obstacle modes.
 - Future branches:
-  - `stage5-safety-local-planner`
   - `stage6-paper-experiment-matrix`
   - `stage7-paper-materials`
 
@@ -44,12 +44,14 @@ Closed milestones:
 - `Stage 1 - Intent-MPC Data Flow`
 - `Stage 2 - Experiment Logging`
 - `Stage 3 - Perception Degradation`
+- `Stage 4 - Multimodal Uncertainty`
+- `Stage 5 - Safety Local Planner`
 
 Current active milestone:
 
-- `Stage 4 - Multimodal Uncertainty`
+- `Stage 6 - Paper Experiment Matrix`
 
-Stage 4 scope is deliberately limited to uncertainty representation and visualization. Planner consumption of `effective_radius` remains reserved for Stage 5.
+Stage 5 implemented dynamic-obstacle size inflation for fixed-margin and uncertainty-aware modes. Risk-cost terms inside MPC remain a later refinement after validating the radius-inflation baseline.
 
 ## GitHub Issues
 

--- a/docs/stage5/README.md
+++ b/docs/stage5/README.md
@@ -1,0 +1,82 @@
+# Stage 5: Safety Local Planner Integration
+
+Goal: make the local planner optionally use dynamic-obstacle safety margins and Stage 4 uncertainty-aware effective radii.
+
+Stage 5 adds a mode switch in `autonomous_flight/mpcNavigation`:
+
+```text
+original
+fixed_margin
+uncertainty_aware
+```
+
+The default remains `original`, so the official Intent-MPC demo behavior is unchanged unless a Stage 5 launch file or parameter explicitly enables a new mode.
+
+## Implemented Modes
+
+`original`
+
+: Existing Intent-MPC behavior. Dynamic obstacles from fake detector/map/predictor are passed into MPC unchanged.
+
+`fixed_margin`
+
+: Inflates dynamic obstacle dimensions by `2 * fixed_safety_margin` before calling MPC. This creates the comparison baseline `Intent-MPC + fixed safety margin`.
+
+`uncertainty_aware`
+
+: Subscribes to `/multimodal_uncertainty/uncertainty_obstacles` and uses each obstacle's `effective_radius` to inflate its planner size. If the predictor is enabled, predicted obstacle sizes are inflated by matching predicted obstacle positions to the nearest uncertainty obstacle. If the predictor is disabled, the current uncertainty obstacles are passed directly to MPC.
+
+## Main Files
+
+- `autonomous_flight/include/autonomous_flight/mpcNavigation.h`
+- `autonomous_flight/include/autonomous_flight/mpcNavigation.cpp`
+- `autonomous_flight/cfg/mpc_navigation/flight_base.yaml`
+- `autonomous_flight/launch/intent_mpc_demo_fixed_margin.launch`
+- `autonomous_flight/launch/intent_mpc_demo_uncertainty.launch`
+
+## Usage
+
+Load the simulator plugin environment before launching Gazebo:
+
+```bash
+source /opt/ros/noetic/setup.bash
+source /home/intent/catkin_ws/devel/setup.bash
+source /home/intent/catkin_ws/src/Intent-MPC/uav_simulator/gazeboSetup.bash
+```
+
+Fixed-margin baseline:
+
+```bash
+roslaunch autonomous_flight intent_mpc_demo_fixed_margin.launch fixed_safety_margin:=0.3
+```
+
+Uncertainty-aware mode:
+
+```bash
+roslaunch autonomous_flight intent_mpc_demo_uncertainty.launch \
+  position_noise_std:=0.1 \
+  velocity_noise_std:=0.2 \
+  delay_ms:=100 \
+  confidence_noise:=0.1
+```
+
+Use the existing simulator launch in a separate terminal:
+
+```bash
+roslaunch uav_simulator start.launch
+```
+
+Both Stage 5 demo launch files use `remote_control/launch/mpc_navigation_fast_rviz.launch`, so they open the lighter `rviz_fast` configuration instead of the heavier original RViz view.
+
+## Stage Boundary
+
+Stage 5 implements radius/size inflation integration. It does not add a new nonlinear risk cost term inside the MPC solver. The risk-cost variant remains a later refinement after validating the safer radius-inflation path.
+
+## Acceptance Checklist
+
+- [x] Original mode remains default.
+- [x] Fixed margin mode exists.
+- [x] Uncertainty-aware mode consumes Stage 4 `effective_radius`.
+- [x] Predictor and non-predictor paths both apply the selected mode.
+- [x] Launch files exist for fixed-margin and uncertainty-aware demos.
+- [x] Catkin build passes.

--- a/docs/stage5/stage5_design.md
+++ b/docs/stage5/stage5_design.md
@@ -1,0 +1,69 @@
+# Stage 5 Design
+
+## Integration Point
+
+Stage 5 integrates at `autonomous_flight/mpcNavigation`, where dynamic obstacles are passed into `trajectory_planner::mpcPlanner`.
+
+Relevant paths:
+
+```text
+mpcNavigation::mpcCB
+  -> predictor_->getPrediction
+  -> mpc_->updatePredObstacles
+
+mpcNavigation::mpcCB
+  -> getDynamicObstacles / dynamicMap::getDynamicObstacles
+  -> mpc_->updateDynamicObstacles
+
+mpcNavigation::hasDynamicCollision
+  -> dynamic obstacle collision check
+```
+
+This keeps the MPC solver itself unchanged and makes the method easy to switch off.
+
+## Modes
+
+`original`
+
+: No modification to dynamic obstacle size.
+
+`fixed_margin`
+
+: Size inflation:
+
+```text
+size_planner = size_raw + 2 * fixed_safety_margin
+```
+
+This is applied to current obstacles and predictor obstacle-size sequences.
+
+`uncertainty_aware`
+
+: Stage 4 gives `radius` and `effective_radius`. The default mapping is:
+
+```text
+scale = max(1, effective_radius / radius)
+size_planner = size_raw * scale
+```
+
+This preserves the obstacle shape while making its bounding radius equal to `effective_radius`. An alternate `add_margin` mode is available:
+
+```text
+size_planner = size_raw + 2 * max(0, effective_radius - radius)
+```
+
+## Predictor Handling
+
+The official demo uses `use_predictor: true`, so Stage 5 also handles `updatePredObstacles`.
+
+For each predicted obstacle, the implementation:
+
+1. selects the first available predicted position,
+2. finds the nearest Stage 4 uncertainty obstacle within `uncertainty_association_distance`,
+3. inflates every predicted size sample for that obstacle using the matched `effective_radius`.
+
+If no fresh uncertainty message is available and `uncertainty_fallback_to_original=true`, the planner uses the original predictor sizes. If fallback is disabled, the predictor obstacle set is cleared for that cycle.
+
+## Boundary
+
+This stage implements constraint inflation through dynamic obstacle size. It does not yet add a separate risk-cost term to the MPC objective.

--- a/docs/stage5/stage5_execution_prompt.md
+++ b/docs/stage5/stage5_execution_prompt.md
@@ -1,0 +1,66 @@
+# Stage 5 Execution Prompt
+
+你现在要完成阶段 5：改进安全局部规划器。
+
+研究背景：阶段 0 已复现 Intent-MPC，阶段 1 已梳理数据流，阶段 2 已建立实验日志系统，阶段 3 已实现感知退化模块，阶段 4 已实现多模态不确定性障碍物表示。阶段 5 要让局部规划器真正利用安全裕度或不确定性半径，但必须保留原始 Intent-MPC 可切换模式。
+
+约束：
+
+- 默认行为必须保持原始 Intent-MPC。
+- 不删除原仓库文件。
+- 尽量只在 `autonomous_flight/mpcNavigation` 入口层接入，不重写 MPC 求解器。
+- 至少实现：
+  - `original`
+  - `fixed_margin`
+  - `uncertainty_aware`
+- 风险代价项可以先作为后续增强；本阶段优先完成可验证的半径/尺寸膨胀路径。
+- 每次新阶段开始时，根据当前实现程度更新阶段内容、边界和项目管理文档。
+
+任务：
+
+1. 读取 GitHub `main` 最新 README，确认阶段 5 要求。
+2. 从 `stage4-multimodal-uncertainty` 创建 `stage5-safety-local-planner` 分支。
+3. 找到动态障碍物进入 MPC 的路径：
+   - `mpcNavigation::mpcCB`
+   - `mpc_->updateDynamicObstacles`
+   - `mpc_->updatePredObstacles`
+   - `mpcNavigation::hasDynamicCollision`
+4. 在 `autonomous_flight` 增加参数：
+   - `dynamic_obstacle_mode`
+   - `fixed_safety_margin`
+   - `uncertainty_obstacles_topic`
+   - `uncertainty_size_mode`
+   - `uncertainty_max_age`
+   - `uncertainty_association_distance`
+   - `uncertainty_fallback_to_original`
+5. 实现 `fixed_margin`：
+   - 对当前动态障碍物尺寸加 `2 * fixed_safety_margin`。
+   - 对 predictor 输出的预测尺寸同样加 `2 * fixed_safety_margin`。
+6. 实现 `uncertainty_aware`：
+   - 订阅 `/multimodal_uncertainty/uncertainty_obstacles`。
+   - 非 predictor 路径直接使用 uncertainty obstacle position/velocity/size。
+   - predictor 路径通过最近邻匹配，把 `effective_radius` 映射到预测障碍物尺寸。
+   - 如果 uncertainty 消息过期且允许 fallback，则回退原始路径。
+7. 增加 launch：
+   - `intent_mpc_demo_fixed_margin.launch`
+   - `intent_mpc_demo_uncertainty.launch`
+8. 写阶段 5 文档：
+   - prompt。
+   - 设计说明。
+   - 使用方式。
+   - 验证结果。
+   - 当前阶段边界：完成半径/尺寸膨胀，风险代价项后续再做。
+9. 验证：
+   - Docker / ROS Noetic 内 `catkin_make`。
+   - `roslaunch autonomous_flight intent_mpc_demo_fixed_margin.launch --nodes`。
+   - `roslaunch autonomous_flight intent_mpc_demo_uncertainty.launch --nodes`。
+   - 必要时做 ROS 参数/订阅 smoke test。
+10. 提交、推送分支，创建 PR，更新 Stage 5 issues/milestone。
+
+验收标准：
+
+- 原始 demo 默认仍是 `original` 模式。
+- fixed-margin launch 可解析并加载参数。
+- uncertainty-aware launch 可解析并启动 Stage 3/4 管线。
+- catkin 构建通过。
+- 代码路径覆盖 predictor 和 non-predictor 两种动态障碍物更新方式。

--- a/docs/stage5/stage5_final_report.md
+++ b/docs/stage5/stage5_final_report.md
@@ -1,0 +1,135 @@
+# Stage 5 Final Report
+
+## Goal
+
+Let the local planner use fixed safety margins and Stage 4 uncertainty-aware effective radii while keeping the original Intent-MPC behavior available as the default baseline.
+
+The latest `uav/main` README asks Stage 5 to prioritize:
+
+1. constraint inflation from `r` to `r_eff`;
+2. a later risk-cost variant;
+3. switchable modes: original Intent-MPC, fixed-margin Intent-MPC, and uncertainty-aware Intent-MPC.
+
+This stage implements the constraint/radius-inflation path first. The nonlinear risk-cost term is kept as a later refinement.
+
+## Implementation
+
+Modified:
+
+- `autonomous_flight/include/autonomous_flight/mpcNavigation.h`
+- `autonomous_flight/include/autonomous_flight/mpcNavigation.cpp`
+- `autonomous_flight/CMakeLists.txt`
+- `autonomous_flight/package.xml`
+- `autonomous_flight/cfg/mpc_navigation/flight_base.yaml`
+
+Added:
+
+- `autonomous_flight/launch/intent_mpc_demo_fixed_margin.launch`
+- `autonomous_flight/launch/intent_mpc_demo_uncertainty.launch`
+
+The integration is in `mpcNavigation`, before dynamic obstacles are passed to `trajectory_planner::mpcPlanner`. The MPC solver implementation is not rewritten.
+
+## Modes
+
+- `original`: pass dynamic obstacles into MPC unchanged.
+- `fixed_margin`: add `2 * fixed_safety_margin` to each dynamic obstacle size.
+- `uncertainty_aware`: subscribe to `/multimodal_uncertainty/uncertainty_obstacles` and inflate obstacle sizes using Stage 4 `effective_radius`.
+
+The default in `flight_base.yaml` is `original`, so the official demo remains unchanged unless a Stage 5 launch file or parameter explicitly enables a new mode.
+
+## Runtime Commands
+
+The Gazebo plugin environment must be loaded before launching the simulator:
+
+```bash
+source /opt/ros/noetic/setup.bash
+source /home/intent/catkin_ws/devel/setup.bash
+source /home/intent/catkin_ws/src/Intent-MPC/uav_simulator/gazeboSetup.bash
+```
+
+Fixed-margin mode:
+
+```bash
+roslaunch uav_simulator start.launch
+roslaunch autonomous_flight intent_mpc_demo_fixed_margin.launch fixed_safety_margin:=0.3
+```
+
+Uncertainty-aware mode:
+
+```bash
+roslaunch uav_simulator start.launch
+roslaunch autonomous_flight intent_mpc_demo_uncertainty.launch
+```
+
+Both Stage 5 launch files use `remote_control/launch/mpc_navigation_fast_rviz.launch`, which opens the lighter `rviz_fast` view used for smoother visualization on this machine.
+
+## Validation Result
+
+Build:
+
+```bash
+catkin_make
+```
+
+Result: passed in the Docker ROS Noetic workspace.
+
+Launch parsing:
+
+```bash
+roslaunch autonomous_flight intent_mpc_demo_fixed_margin.launch --nodes
+roslaunch autonomous_flight intent_mpc_demo_uncertainty.launch --nodes
+```
+
+Result:
+
+- fixed-margin nodes: `/tracking_controller_node`, `/mpc_navigation_node`, `/rviz_fast`
+- uncertainty-aware nodes: `/perception_degradation_node`, `/uncertainty_obstacle_node`, `/tracking_controller_node`, `/mpc_navigation_node`, `/rviz_fast`
+
+Runtime smoke test with simulator:
+
+- `fixed_margin` loaded `/autonomous_flight/dynamic_obstacle_mode=fixed_margin`.
+- `fixed_margin` loaded `/autonomous_flight/fixed_safety_margin=0.3`.
+- `uncertainty_aware` loaded `/autonomous_flight/dynamic_obstacle_mode=uncertainty_aware`.
+- `uncertainty_aware` loaded `/autonomous_flight/uncertainty_obstacles_topic=/multimodal_uncertainty/uncertainty_obstacles`.
+- `mpcNavigation` reported `Odom and mavros topics are ready`.
+- `mpcNavigation` reported `Takeoff succeed`.
+
+Observed key topics:
+
+- `/CERLAB/quadcopter/odom`: `nav_msgs/Odometry`
+- `/CERLAB/quadcopter/pose`
+- `/CERLAB/quadcopter/vel`
+- `/dynamic_predictor/intent_probability`
+- `/dynamic_predictor/predict_trajectories`
+- `/mpcNavigation/mpc_trajectory`: `nav_msgs/Path`
+- `/mpc_planner/dynamic_obstacles`: `visualization_msgs/MarkerArray`
+- `/mpc_planner/mpc_trajectory`
+- `/mpc_planner/candidate_trajectories`
+- `/perception_degradation/degraded_obstacles`: `perception_degradation/DegradedObstacleArray`
+- `/multimodal_uncertainty/uncertainty_obstacles`: `multimodal_uncertainty/UncertaintyObstacleArray`
+
+## Issue Found
+
+During the first smoke test, `mpcNavigation` stayed at the odometry wait step because the test shell had not loaded `uav_simulator/gazeboSetup.bash`. In that state, the throttled odom topic existed but the Gazebo quadcopter plugin did not publish real odometry messages.
+
+Resolution:
+
+```bash
+source /home/intent/catkin_ws/src/Intent-MPC/uav_simulator/gazeboSetup.bash
+```
+
+After loading the Gazebo plugin path, odometry, predictor topics, MPC trajectory topics, and Stage 3/4 obstacle topics were all present.
+
+## Boundary
+
+Stage 5 implements radius/size inflation. A nonlinear risk-cost term inside MPC remains a follow-up after validating the constraint-inflation baseline with Stage 6 experiments.
+
+## Acceptance
+
+Stage 5 satisfies the acceptance criteria for the current staged implementation:
+
+- original mode remains the default;
+- fixed-margin mode builds, launches, and publishes planner topics;
+- uncertainty-aware mode builds, launches, starts the Stage 3/4 pipeline, and publishes uncertainty obstacle topics;
+- predictor and non-predictor dynamic obstacle update paths both apply the selected planner mode;
+- smoother visualization is available through the lightweight `rviz_fast` launch.


### PR DESCRIPTION
## Summary
- Add switchable `autonomous_flight/dynamic_obstacle_mode`: `original`, `fixed_margin`, `uncertainty_aware`.
- Keep official Intent-MPC behavior as the default `original` mode.
- Inflate dynamic obstacle sizes before MPC for fixed-margin and Stage 4 `effective_radius` modes.
- Cover both predictor and non-predictor dynamic-obstacle update paths.
- Add Stage 5 launch files and documentation.

## Validation
- `catkin_make` passed in the Docker ROS Noetic workspace.
- `roslaunch autonomous_flight intent_mpc_demo_fixed_margin.launch --nodes` passed.
- `roslaunch autonomous_flight intent_mpc_demo_uncertainty.launch --nodes` passed.
- Runtime smoke tests passed for `fixed_margin` and `uncertainty_aware` after sourcing `uav_simulator/gazeboSetup.bash`.
- Observed `/mpcNavigation/mpc_trajectory`, `/mpc_planner/dynamic_obstacles`, `/dynamic_predictor/predict_trajectories`, `/perception_degradation/degraded_obstacles`, and `/multimodal_uncertainty/uncertainty_obstacles`.

## Boundary
This stage implements radius/size inflation. A nonlinear MPC risk-cost term is left for a later refinement after Stage 6 experiment validation.

Closes #13
Closes #14
