### PR TITLE
Stage 6: paper experiment matrix tooling

### DIFF
--- a/autonomous_flight/launch/intent_mpc_demo_stage6.launch
+++ b/autonomous_flight/launch/intent_mpc_demo_stage6.launch
@@ -1,0 +1,59 @@
+<launch>
+  <arg name="dynamic_obstacle_mode" default="original" />
+  <arg name="fixed_safety_margin" default="0.0" />
+  <arg name="enable_uncertainty_pipeline" default="false" />
+  <arg name="rviz" default="false" />
+
+  <arg name="position_noise_std" default="0.0" />
+  <arg name="velocity_noise_std" default="0.0" />
+  <arg name="delay_ms" default="0.0" />
+  <arg name="dropout_prob" default="0.0" />
+  <arg name="false_positive_prob" default="0.0" />
+  <arg name="confidence_noise" default="0.0" />
+  <arg name="random_seed" default="0" />
+  <arg name="alpha" default="1.0" />
+  <arg name="beta" default="0.5" />
+  <arg name="gamma" default="0.002" />
+  <arg name="delta" default="0.8" />
+  <arg name="output_dir" default="$(env HOME)/catkin_ws/experiment_logs/stage6" />
+
+  <rosparam file="$(find tracking_controller)/cfg/controller_param.yaml" ns="controller" />
+  <rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/fake_detector_param.yaml" />
+  <rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/flight_base.yaml" ns="autonomous_flight" />
+  <rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/planner_param.yaml" />
+  <rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/mapping_param.yaml" ns="/dynamic_map" />
+  <rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/dynamic_detector_param.yaml" ns="/onboard_detector" />
+  <rosparam file="$(find autonomous_flight)/cfg/mpc_navigation/predictor_param.yaml" ns="/dynamic_predictor" />
+
+  <param name="autonomous_flight/dynamic_obstacle_mode" value="$(arg dynamic_obstacle_mode)" />
+  <param name="autonomous_flight/fixed_safety_margin" value="$(arg fixed_safety_margin)" />
+  <param name="autonomous_flight/uncertainty_obstacles_topic" value="/multimodal_uncertainty/uncertainty_obstacles" />
+  <param name="autonomous_flight/uncertainty_size_mode" value="scale_radius" />
+  <param name="autonomous_flight/uncertainty_max_age" value="0.5" />
+  <param name="autonomous_flight/uncertainty_association_distance" value="2.0" />
+  <param name="autonomous_flight/uncertainty_fallback_to_original" value="true" />
+
+  <group if="$(arg enable_uncertainty_pipeline)">
+    <include file="$(find multimodal_uncertainty)/launch/run_stage4_pipeline.launch">
+      <arg name="output_dir" value="$(arg output_dir)" />
+      <arg name="position_noise_std" value="$(arg position_noise_std)" />
+      <arg name="velocity_noise_std" value="$(arg velocity_noise_std)" />
+      <arg name="delay_ms" value="$(arg delay_ms)" />
+      <arg name="dropout_prob" value="$(arg dropout_prob)" />
+      <arg name="false_positive_prob" value="$(arg false_positive_prob)" />
+      <arg name="confidence_noise" value="$(arg confidence_noise)" />
+      <arg name="random_seed" value="$(arg random_seed)" />
+      <arg name="alpha" value="$(arg alpha)" />
+      <arg name="beta" value="$(arg beta)" />
+      <arg name="gamma" value="$(arg gamma)" />
+      <arg name="delta" value="$(arg delta)" />
+    </include>
+  </group>
+
+  <node pkg="tracking_controller" type="tracking_controller_node" name="tracking_controller_node" output="screen" />
+  <node pkg="autonomous_flight" type="mpc_navigation_node" name="mpc_navigation_node" output="screen" />
+
+  <group if="$(arg rviz)">
+    <include file="$(find remote_control)/launch/mpc_navigation_fast_rviz.launch" />
+  </group>
+</launch>

--- a/docs/project_management/github_workflow.md
+++ b/docs/project_management/github_workflow.md
@@ -15,8 +15,8 @@ The `main` branch currently stores the high-level research plan. The reproductio
 - `stage3-perception-degradation`: stage 3 perception degradation node, degraded obstacle messages, RViz markers, and CSV samples.
 - `stage4-multimodal-uncertainty`: stage 4 uncertainty obstacle messages, effective-radius calculation, RViz risk radius markers, and CSV samples.
 - `stage5-safety-local-planner`: stage 5 planner integration for original, fixed-margin, and uncertainty-aware dynamic obstacle modes.
+- `stage6-paper-experiment-matrix`: stage 6 experiment matrix, headless batch runner, summary tables, and robustness curves.
 - Future branches:
-  - `stage6-paper-experiment-matrix`
   - `stage7-paper-materials`
 
 Each stage should end with:
@@ -46,12 +46,13 @@ Closed milestones:
 - `Stage 3 - Perception Degradation`
 - `Stage 4 - Multimodal Uncertainty`
 - `Stage 5 - Safety Local Planner`
+- `Stage 6 - Paper Experiment Matrix`
 
 Current active milestone:
 
-- `Stage 6 - Paper Experiment Matrix`
+- `Stage 7 - Paper Materials`
 
-Stage 5 implemented dynamic-obstacle size inflation for fixed-margin and uncertainty-aware modes. Risk-cost terms inside MPC remain a later refinement after validating the radius-inflation baseline.
+Stage 6 implemented the experiment matrix and offline analysis workflow. The full 585-run matrix has not been executed in this branch; only a short pilot run was used to validate the pipeline.
 
 ## GitHub Issues
 

--- a/docs/stage6/README.md
+++ b/docs/stage6/README.md
@@ -1,0 +1,101 @@
+# Stage 6: Paper Experiment Matrix
+
+Goal: turn the Stage 5 planner modes into a repeatable paper experiment workflow.
+
+Stage 6 adds:
+
+- a YAML experiment matrix;
+- a manifest generator;
+- a headless batch runner;
+- Stage 6 recorder metadata;
+- summary/table/SVG analysis tools.
+
+## Files
+
+- `experiment_tools/config/stage6_matrix.yaml`
+- `experiment_tools/scripts/generate_stage6_manifest.py`
+- `experiment_tools/scripts/run_stage6_batch.py`
+- `experiment_tools/scripts/analyze_stage6_results.py`
+- `experiment_tools/launch/record_stage6.launch`
+- `uav_simulator/launch/start_stage6.launch`
+- `autonomous_flight/launch/intent_mpc_demo_stage6.launch`
+
+## Generate Manifest
+
+Inside the ROS Noetic Docker/container workspace:
+
+```bash
+source /opt/ros/noetic/setup.bash
+source ~/catkin_ws/devel/setup.bash
+
+rosrun experiment_tools generate_stage6_manifest.py \
+  --config ~/catkin_ws/src/Intent-MPC/experiment_tools/config/stage6_matrix.yaml \
+  --output ~/catkin_ws/experiment_logs/stage6/stage6_manifest.csv
+```
+
+The default matrix produces 585 executable runs:
+
+```text
+3 enabled methods x 5 scenarios x 3 seeds x 13 conditions
+```
+
+NavRL and NavRL + safety shield are present as disabled placeholders until a launch integration exists.
+
+## Dry Run Commands
+
+```bash
+rosrun experiment_tools run_stage6_batch.py \
+  --manifest ~/catkin_ws/experiment_logs/stage6/stage6_manifest.csv \
+  --output-dir ~/catkin_ws/experiment_logs/stage6 \
+  --limit 3
+```
+
+This prints the simulator, planner, and recorder commands without launching them.
+
+## Execute A Pilot Batch
+
+```bash
+rosrun experiment_tools run_stage6_batch.py \
+  --manifest ~/catkin_ws/experiment_logs/stage6/stage6_manifest.csv \
+  --output-dir ~/catkin_ws/experiment_logs/stage6 \
+  --limit 1 \
+  --run-duration-sec 60 \
+  --execute
+```
+
+Outputs:
+
+```text
+~/catkin_ws/experiment_logs/stage6/stage6_runs.csv
+~/catkin_ws/experiment_logs/stage6/stage6_samples.csv
+~/catkin_ws/experiment_logs/stage6/logs/<run_id>/
+```
+
+## Analyze Results
+
+```bash
+rosrun experiment_tools analyze_stage6_results.py \
+  --input ~/catkin_ws/experiment_logs/stage6/stage6_runs.csv \
+  --output-dir ~/catkin_ws/experiment_logs/stage6/analysis
+```
+
+Outputs:
+
+- `stage6_summary.csv`
+- `stage6_method_comparison_overall.csv`
+- `stage6_method_comparison_by_scenario.csv`
+- `stage6_robustness.csv`
+- `stage6_tables.md`
+- `plots/*_success_rate.svg`
+- `plots/*_collision_rate.svg`
+- `plots/*_min_distance_mean.svg`
+
+## Boundary
+
+Current executable comparisons cover the Intent-MPC family:
+
+- `intent_mpc`
+- `intent_mpc_fixed_margin`
+- `uncertainty_aware_intent_mpc`
+
+In the current code path, Stage 3/4 degraded uncertainty is consumed by `uncertainty_aware_intent_mpc`. The original and fixed-margin modes still use the existing Intent-MPC detector/predictor path. Treat those as ideal-perception baselines unless a common degraded-obstacle adapter is added before final paper claims.

--- a/docs/stage6/stage6_execution_prompt.md
+++ b/docs/stage6/stage6_execution_prompt.md
@@ -1,0 +1,66 @@
+# Stage 6 Execution Prompt
+
+你现在要完成阶段 6：论文实验矩阵与批量统计工具。
+
+研究背景：阶段 0 已复现 Intent-MPC，阶段 1 已梳理数据流，阶段 2 已建立实验记录系统，阶段 3 已实现感知退化，阶段 4 已实现不确定性障碍物表示，阶段 5 已接入 `original`、`fixed_margin`、`uncertainty_aware` 三种局部规划模式。阶段 6 的目标不是继续改规划算法，而是把论文实验所需的“方法 × 场景 × 退化维度 × 随机种子”批量实验流程落地。
+
+约束：
+
+- 不修改 Stage 5 的避障算法逻辑。
+- 不删除原仓库文件。
+- 默认保留官方 Intent-MPC 行为。
+- 批量实验应支持 headless Gazebo，避免不必要的 RViz/Gazebo GUI 负担。
+- NavRL 尚未接入本仓库时，只保留 disabled 占位，不生成可执行 NavRL run。
+- 每次新阶段开始时，根据当前实现程度更新阶段内容、边界和项目管理文档。
+
+任务：
+
+1. 读取 `uav/main` README 中阶段 6 要求。
+2. 从 `stage5-safety-local-planner` 创建 `stage6-paper-experiment-matrix` 分支。
+3. 定义实验矩阵配置：
+   - 方法：Intent-MPC、Intent-MPC + fixed safety margin、uncertainty-aware Intent-MPC。
+   - 预留方法：NavRL、NavRL + safety shield，默认 disabled。
+   - 场景：单动态障碍物横穿、正面/走廊、多个障碍物交叉、遮挡/复杂平面、窄通道会车。
+   - 退化维度：位置噪声、速度噪声、延迟、漏检率。
+   - 随机种子。
+4. 增加 headless 仿真 launch：
+   - 可传 `world_name`。
+   - 默认不启动 Gazebo GUI。
+   - 默认不启动 keyboard control。
+5. 增加 Stage 6 planner launch：
+   - 可传 `dynamic_obstacle_mode`。
+   - 可开关 Stage 3/4 uncertainty pipeline。
+   - 可开关 RViz。
+6. 扩展 recorder 元数据字段：
+   - `world_name`
+   - `planner_mode`
+   - `fixed_safety_margin`
+   - `degradation_axis`
+   - `degradation_value`
+7. 实现工具脚本：
+   - `generate_stage6_manifest.py`
+   - `run_stage6_batch.py`
+   - `analyze_stage6_results.py`
+8. 生成文档：
+   - 使用方式。
+   - 实验矩阵设计。
+   - 验证结果。
+   - 当前阶段边界。
+9. 验证：
+   - Python 语法检查。
+   - manifest 生成。
+   - dry-run 命令生成。
+   - synthetic CSV 分析输出 summary/table/SVG。
+   - Docker ROS Noetic 内 `catkin_make`。
+   - 关键 launch `--nodes`。
+   - 1 条短时 headless pilot run 写出 CSV。
+10. 提交、推送分支，创建 PR，更新 Stage 6 issues/milestone。
+
+验收标准：
+
+- 能生成 Stage 6 manifest CSV。
+- 能打印或执行批量实验命令。
+- 能从 Stage 6 run CSV 生成 summary CSV、method comparison table、robustness table、SVG 曲线。
+- Headless launch 可解析。
+- `catkin_make` 通过。
+- 至少 1 条 pilot run 能写出 `stage6_runs.csv`。

--- a/docs/stage6/stage6_experiment_design.md
+++ b/docs/stage6/stage6_experiment_design.md
@@ -1,0 +1,81 @@
+# Stage 6 Experiment Design
+
+## Matrix Shape
+
+The default matrix is one-factor-at-a-time:
+
+```text
+clean baseline
+position_noise_std: 0.1, 0.2, 0.3 m
+delay_ms: 100, 200, 300 ms
+dropout_prob: 0.1, 0.3, 0.5
+velocity_noise_std: 0.2, 0.5, 1.0 m/s
+```
+
+This gives 13 conditions per method/scenario/seed. It avoids the full factorial explosion while producing clear robustness curves.
+
+## Enabled Methods
+
+`intent_mpc`
+
+: Stage 5 `original` mode.
+
+`intent_mpc_fixed_margin`
+
+: Stage 5 `fixed_margin` mode with `fixed_safety_margin=0.3`.
+
+`uncertainty_aware_intent_mpc`
+
+: Stage 5 `uncertainty_aware` mode with the Stage 3/4 degradation and uncertainty pipeline enabled.
+
+## Disabled Placeholders
+
+`navrl` and `navrl_safety_shield` are present in `stage6_matrix.yaml` but disabled. They should be enabled only after a real NavRL launch path exists.
+
+## Scenarios
+
+The scenario names map to existing Gazebo worlds:
+
+- `single_dynamic_crossing`: `simple_box/simple_box_dynamic_3.world`
+- `head_on_corridor`: `corridor/corridor_dynamic_9.world`
+- `multi_obstacle_crossing`: `square/square_dynamic_7.world`
+- `sudden_occlusion_floorplan`: `floorplan3/floorplan3_box_dynamic_4.world`
+- `narrow_passage_meeting`: `tunnel/tunnel_straight_dynamic_5.world`
+
+These names are paper-facing labels. They may still need visual confirmation before final experiments.
+
+## Metrics
+
+The Stage 2 recorder provides:
+
+- success
+- collision
+- minimum distance
+- path length
+- travel time
+- average speed
+- optional planning time
+
+Stage 6 adds metadata:
+
+- world name
+- planner mode
+- fixed safety margin
+- degradation axis
+- degradation value
+
+## Analysis Outputs
+
+`analyze_stage6_results.py` creates:
+
+- per-scenario/method/degradation summary;
+- clean-condition method comparison;
+- robustness table by degradation axis and value;
+- success, collision, and minimum-distance SVG curves.
+
+## Fairness Note
+
+The current Stage 5 architecture keeps `original` and `fixed_margin` on the original detector/predictor path. The uncertainty-aware method consumes the Stage 4 uncertainty topic. For final paper claims under degraded perception, either:
+
+1. present original/fixed-margin as ideal-perception baselines; or
+2. add a common degraded-obstacle adapter so all methods consume the same degraded obstacle state.

--- a/docs/stage6/stage6_final_report.md
+++ b/docs/stage6/stage6_final_report.md
@@ -1,0 +1,201 @@
+# Stage 6 Final Report
+
+## Goal
+
+Build the paper experiment workflow for comparing Stage 5 planner modes under controlled scenario and perception-degradation settings.
+
+The latest `uav/main` README defines Stage 6 around:
+
+- comparison methods;
+- dynamic-obstacle scenarios;
+- degradation dimensions;
+- `summary.csv`;
+- success, collision, and minimum-distance tables/curves.
+
+## Implementation
+
+Added:
+
+- `experiment_tools/config/stage6_matrix.yaml`
+- `experiment_tools/scripts/generate_stage6_manifest.py`
+- `experiment_tools/scripts/run_stage6_batch.py`
+- `experiment_tools/scripts/analyze_stage6_results.py`
+- `experiment_tools/launch/record_stage6.launch`
+- `uav_simulator/launch/start_stage6.launch`
+- `autonomous_flight/launch/intent_mpc_demo_stage6.launch`
+
+Modified:
+
+- `experiment_tools/scripts/experiment_metric_recorder.py`
+- `experiment_tools/CMakeLists.txt`
+
+## Matrix
+
+Default executable matrix:
+
+```text
+3 enabled methods
+5 scenarios
+3 seeds
+13 degradation conditions
+= 585 runs
+```
+
+Enabled methods:
+
+- `intent_mpc`
+- `intent_mpc_fixed_margin`
+- `uncertainty_aware_intent_mpc`
+
+Disabled placeholders:
+
+- `navrl`
+- `navrl_safety_shield`
+
+## Main Commands
+
+Generate manifest:
+
+```bash
+rosrun experiment_tools generate_stage6_manifest.py \
+  --config ~/catkin_ws/src/Intent-MPC/experiment_tools/config/stage6_matrix.yaml \
+  --output ~/catkin_ws/experiment_logs/stage6/stage6_manifest.csv
+```
+
+Dry run:
+
+```bash
+rosrun experiment_tools run_stage6_batch.py \
+  --manifest ~/catkin_ws/experiment_logs/stage6/stage6_manifest.csv \
+  --output-dir ~/catkin_ws/experiment_logs/stage6 \
+  --limit 3
+```
+
+Execute:
+
+```bash
+rosrun experiment_tools run_stage6_batch.py \
+  --manifest ~/catkin_ws/experiment_logs/stage6/stage6_manifest.csv \
+  --output-dir ~/catkin_ws/experiment_logs/stage6 \
+  --limit 1 \
+  --run-duration-sec 60 \
+  --execute
+```
+
+Analyze:
+
+```bash
+rosrun experiment_tools analyze_stage6_results.py \
+  --input ~/catkin_ws/experiment_logs/stage6/stage6_runs.csv \
+  --output-dir ~/catkin_ws/experiment_logs/stage6/analysis
+```
+
+## Validation
+
+Python syntax:
+
+```bash
+python3 -m py_compile \
+  experiment_tools/scripts/experiment_metric_recorder.py \
+  experiment_tools/scripts/generate_stage6_manifest.py \
+  experiment_tools/scripts/run_stage6_batch.py \
+  experiment_tools/scripts/analyze_stage6_results.py \
+  experiment_tools/scripts/summarize_runs.py \
+  experiment_tools/scripts/plot_metrics.py
+```
+
+Result: passed.
+
+Manifest generation:
+
+```bash
+python3 experiment_tools/scripts/generate_stage6_manifest.py \
+  --config experiment_tools/config/stage6_matrix.yaml \
+  --output /tmp/stage6_manifest.csv
+```
+
+Result: 585 manifest rows plus header. NavRL placeholders were skipped as disabled.
+
+Dry-run command generation:
+
+```bash
+python3 experiment_tools/scripts/run_stage6_batch.py \
+  --manifest /tmp/stage6_pilot_manifest.csv \
+  --workspace /home/intent/catkin_ws \
+  --output-dir /tmp/stage6_out \
+  --limit 2
+```
+
+Result: printed simulator, planner, and recorder commands.
+
+Synthetic analysis:
+
+```bash
+python3 experiment_tools/scripts/analyze_stage6_results.py \
+  --input <synthetic_stage6_runs.csv> \
+  --output-dir <tmp>/out
+```
+
+Result: generated `stage6_summary.csv`, method comparison CSV files, `stage6_robustness.csv`, `stage6_tables.md`, and SVG robustness plots.
+
+Docker ROS Noetic build:
+
+```bash
+catkin_make
+```
+
+Result: passed. Stage 6 scripts were installed into `devel/lib/experiment_tools`.
+
+Launch parsing:
+
+```bash
+roslaunch uav_simulator start_stage6.launch --nodes
+roslaunch autonomous_flight intent_mpc_demo_stage6.launch --nodes
+roslaunch autonomous_flight intent_mpc_demo_stage6.launch dynamic_obstacle_mode:=uncertainty_aware enable_uncertainty_pipeline:=true --nodes
+roslaunch experiment_tools record_stage6.launch --nodes
+```
+
+Result: passed.
+
+Pilot runtime:
+
+```bash
+python3 experiment_tools/scripts/run_stage6_batch.py \
+  --manifest /tmp/stage6_smoke_manifest.csv \
+  --output-dir /tmp/stage6_smoke \
+  --limit 1 \
+  --run-duration-sec 8 \
+  --odom-timeout-sec 90 \
+  --execute
+```
+
+Result: passed. The runner produced:
+
+- `/tmp/stage6_smoke/stage6_runs.csv`
+- `/tmp/stage6_smoke/stage6_samples.csv`
+- per-run simulator/planner/recorder logs
+
+The 8-second smoke run is shorter than the configured success threshold, so its `success=0` is expected.
+
+## Boundary
+
+Stage 6 provides the experiment infrastructure and validates one pilot run. It does not execute the full 585-run matrix in this commit.
+
+Current comparison fairness:
+
+- `uncertainty_aware_intent_mpc` consumes Stage 3/4 degraded uncertainty.
+- `intent_mpc` and `intent_mpc_fixed_margin` still use the original detector/predictor path.
+
+Before final paper claims, decide whether to present original/fixed-margin as ideal-perception baselines or add a common degraded-obstacle adapter for all methods.
+
+## Acceptance
+
+Stage 6 satisfies the implementation acceptance criteria:
+
+- Stage 6 prompt and design docs exist.
+- Manifest generation works.
+- Batch dry-run works.
+- Headless batch execution works for one pilot run.
+- Stage 6 CSV analysis and SVG generation work on synthetic data.
+- Docker catkin build passes.
+- Launch parsing passes.

--- a/experiment_tools/CMakeLists.txt
+++ b/experiment_tools/CMakeLists.txt
@@ -14,6 +14,9 @@ catkin_install_python(PROGRAMS
   scripts/experiment_metric_recorder.py
   scripts/summarize_runs.py
   scripts/plot_metrics.py
+  scripts/generate_stage6_manifest.py
+  scripts/run_stage6_batch.py
+  scripts/analyze_stage6_results.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/experiment_tools/config/stage6_matrix.yaml
+++ b/experiment_tools/config/stage6_matrix.yaml
@@ -1,0 +1,89 @@
+# Stage 6 paper experiment matrix.
+#
+# The default matrix is a one-factor robustness sweep:
+# clean baseline plus one degraded perception dimension changed at a time.
+# This avoids the full factorial explosion while still producing paper-ready
+# robustness curves for noise, delay, dropout, and velocity error.
+
+run_duration_sec: 60
+include_axis_zero: false
+
+launch:
+  sim_pkg: uav_simulator
+  sim_launch: start_stage6.launch
+  planner_pkg: autonomous_flight
+  planner_launch: intent_mpc_demo_stage6.launch
+  recorder_pkg: experiment_tools
+  recorder_launch: record_stage6.launch
+
+methods:
+  - name: intent_mpc
+    enabled: true
+    planner_mode: original
+    fixed_safety_margin: 0.0
+    enable_uncertainty_pipeline: false
+
+  - name: intent_mpc_fixed_margin
+    enabled: true
+    planner_mode: fixed_margin
+    fixed_safety_margin: 0.3
+    enable_uncertainty_pipeline: false
+
+  - name: uncertainty_aware_intent_mpc
+    enabled: true
+    planner_mode: uncertainty_aware
+    fixed_safety_margin: 0.0
+    enable_uncertainty_pipeline: true
+
+  # Future comparison target. Disabled until a NavRL launch integration exists.
+  - name: navrl
+    enabled: false
+    planner_mode: navrl
+    fixed_safety_margin: 0.0
+    enable_uncertainty_pipeline: false
+
+  # Future comparison target. Disabled until a NavRL safety-shield integration exists.
+  - name: navrl_safety_shield
+    enabled: false
+    planner_mode: navrl_safety_shield
+    fixed_safety_margin: 0.0
+    enable_uncertainty_pipeline: true
+
+scenarios:
+  - name: single_dynamic_crossing
+    world_name: $(find uav_simulator)/worlds/simple_box/simple_box_dynamic_3.world
+
+  - name: head_on_corridor
+    world_name: $(find uav_simulator)/worlds/corridor/corridor_dynamic_9.world
+
+  - name: multi_obstacle_crossing
+    world_name: $(find uav_simulator)/worlds/square/square_dynamic_7.world
+
+  - name: sudden_occlusion_floorplan
+    world_name: $(find uav_simulator)/worlds/floorplan3/floorplan3_box_dynamic_4.world
+
+  - name: narrow_passage_meeting
+    world_name: $(find uav_simulator)/worlds/tunnel/tunnel_straight_dynamic_5.world
+
+seeds: [0, 1, 2]
+
+degradation_defaults:
+  position_noise_std: 0.0
+  velocity_noise_std: 0.0
+  delay_ms: 0.0
+  dropout_prob: 0.0
+  false_positive_prob: 0.0
+  confidence_noise: 0.0
+
+degradation_sweeps:
+  - axis: position_noise_std
+    values: [0.0, 0.1, 0.2, 0.3]
+
+  - axis: delay_ms
+    values: [0.0, 100.0, 200.0, 300.0]
+
+  - axis: dropout_prob
+    values: [0.0, 0.1, 0.3, 0.5]
+
+  - axis: velocity_noise_std
+    values: [0.0, 0.2, 0.5, 1.0]

--- a/experiment_tools/launch/record_stage6.launch
+++ b/experiment_tools/launch/record_stage6.launch
@@ -1,0 +1,47 @@
+<launch>
+  <arg name="scenario_name" default="generated_env" />
+  <arg name="method_name" default="intent_mpc_baseline" />
+  <arg name="run_id" default="" />
+  <arg name="world_name" default="" />
+  <arg name="planner_mode" default="original" />
+  <arg name="fixed_safety_margin" default="0.0" />
+  <arg name="degradation_axis" default="clean" />
+  <arg name="degradation_value" default="0" />
+  <arg name="output_dir" default="$(env HOME)/catkin_ws/experiment_logs/stage6" />
+  <arg name="output_csv" default="stage6_runs.csv" />
+  <arg name="sample_csv" default="stage6_samples.csv" />
+
+  <arg name="position_noise_std" default="0.0" />
+  <arg name="velocity_noise_std" default="0.0" />
+  <arg name="delay_ms" default="0.0" />
+  <arg name="dropout_prob" default="0.0" />
+  <arg name="false_positive_prob" default="0.0" />
+  <arg name="confidence_noise" default="0.0" />
+  <arg name="random_seed" default="0" />
+  <arg name="success_min_duration" default="45.0" />
+  <arg name="write_sample_csv" default="true" />
+
+  <node pkg="experiment_tools" type="experiment_metric_recorder.py" name="experiment_metric_recorder" output="screen">
+    <rosparam file="$(find experiment_tools)/config/stage2_default.yaml" />
+    <param name="scenario_name" value="$(arg scenario_name)" />
+    <param name="method_name" value="$(arg method_name)" />
+    <param name="run_id" value="$(arg run_id)" />
+    <param name="world_name" value="$(arg world_name)" />
+    <param name="planner_mode" value="$(arg planner_mode)" />
+    <param name="fixed_safety_margin" value="$(arg fixed_safety_margin)" />
+    <param name="degradation_axis" value="$(arg degradation_axis)" />
+    <param name="degradation_value" value="$(arg degradation_value)" />
+    <param name="output_dir" value="$(arg output_dir)" />
+    <param name="output_csv" value="$(arg output_csv)" />
+    <param name="sample_csv" value="$(arg sample_csv)" />
+    <param name="position_noise_std" value="$(arg position_noise_std)" />
+    <param name="velocity_noise_std" value="$(arg velocity_noise_std)" />
+    <param name="delay_ms" value="$(arg delay_ms)" />
+    <param name="dropout_prob" value="$(arg dropout_prob)" />
+    <param name="false_positive_prob" value="$(arg false_positive_prob)" />
+    <param name="confidence_noise" value="$(arg confidence_noise)" />
+    <param name="random_seed" value="$(arg random_seed)" />
+    <param name="success_min_duration" value="$(arg success_min_duration)" />
+    <param name="write_sample_csv" value="$(arg write_sample_csv)" />
+  </node>
+</launch>

--- a/experiment_tools/scripts/analyze_stage6_results.py
+++ b/experiment_tools/scripts/analyze_stage6_results.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import html
+import math
+import os
+from collections import defaultdict
+
+
+SUMMARY_GROUP = [
+    "scenario_name",
+    "method_name",
+    "planner_mode",
+    "degradation_axis",
+    "degradation_value",
+    "position_noise_std",
+    "velocity_noise_std",
+    "delay_ms",
+    "dropout_prob",
+]
+
+METRICS = [
+    "run_count",
+    "success_rate",
+    "collision_rate",
+    "min_distance_mean",
+    "min_distance_min",
+    "path_length_mean",
+    "travel_time_mean",
+    "average_speed_mean",
+    "planning_time_mean",
+    "planning_time_max",
+]
+
+
+def to_float(value):
+    try:
+        number = float(value)
+        return number if math.isfinite(number) else math.nan
+    except (TypeError, ValueError):
+        return math.nan
+
+
+def to_bool(value):
+    text = str(value).strip().lower()
+    return text in ("1", "true", "yes", "success")
+
+
+def finite_values(rows, key):
+    values = [to_float(row.get(key, "")) for row in rows]
+    return [value for value in values if math.isfinite(value)]
+
+
+def mean(values):
+    if not values:
+        return math.nan
+    return sum(values) / len(values)
+
+
+def summarize(rows):
+    successes = [1.0 if to_bool(row.get("success", "")) else 0.0 for row in rows]
+    collisions = [1.0 if to_bool(row.get("collision", "")) else 0.0 for row in rows]
+    min_distances = finite_values(rows, "min_distance")
+    path_lengths = finite_values(rows, "path_length")
+    travel_times = finite_values(rows, "travel_time")
+    average_speeds = finite_values(rows, "average_speed")
+    planning_times = finite_values(rows, "planning_time")
+    planning_time_maxes = finite_values(rows, "planning_time_max")
+    return {
+        "run_count": len(rows),
+        "success_rate": mean(successes),
+        "collision_rate": mean(collisions),
+        "min_distance_mean": mean(min_distances),
+        "min_distance_min": min(min_distances) if min_distances else math.nan,
+        "path_length_mean": mean(path_lengths),
+        "travel_time_mean": mean(travel_times),
+        "average_speed_mean": mean(average_speeds),
+        "planning_time_mean": mean(planning_times),
+        "planning_time_max": max(planning_time_maxes) if planning_time_maxes else math.nan,
+    }
+
+
+def group_rows(rows, columns):
+    groups = defaultdict(list)
+    for row in rows:
+        key = tuple(row.get(column, "") for column in columns)
+        groups[key].append(row)
+    output = []
+    for key, group in sorted(groups.items()):
+        row = {column: value for column, value in zip(columns, key)}
+        row.update(summarize(group))
+        output.append(row)
+    return output
+
+
+def write_csv(path, fieldnames, rows):
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: row.get(key, "") for key in fieldnames})
+
+
+def clean_rows(rows):
+    return [row for row in rows if row.get("degradation_axis", "clean") == "clean"]
+
+
+def robustness_rows(rows):
+    axes = sorted({row.get("degradation_axis", "") for row in rows if row.get("degradation_axis", "") not in ("", "clean")})
+    output = []
+    clean_by_method = group_rows(clean_rows(rows), ["method_name", "planner_mode"])
+    for axis in axes:
+        for clean in clean_by_method:
+            row = dict(clean)
+            row["degradation_axis"] = axis
+            row["degradation_value"] = "0"
+            output.append(row)
+    nonclean = [row for row in rows if row.get("degradation_axis", "") not in ("", "clean")]
+    output.extend(group_rows(nonclean, ["degradation_axis", "degradation_value", "method_name", "planner_mode"]))
+    output.sort(key=lambda row: (row.get("degradation_axis", ""), to_float(row.get("degradation_value", "")), row.get("method_name", "")))
+    return output
+
+
+def value_range(values, default_min=0.0, default_max=1.0):
+    if not values:
+        return default_min, default_max
+    lo = min(values)
+    hi = max(values)
+    if math.isclose(lo, hi):
+        pad = 0.5 if math.isclose(lo, 0.0) else abs(lo) * 0.1
+        return lo - pad, hi + pad
+    pad = (hi - lo) * 0.08
+    return lo - pad, hi + pad
+
+
+def write_svg_curve(rows, axis, metric, ylabel, path):
+    axis_rows = [row for row in rows if row.get("degradation_axis") == axis and math.isfinite(to_float(row.get(metric, "")))]
+    grouped = defaultdict(list)
+    for row in axis_rows:
+        grouped[row.get("method_name", "method")].append((to_float(row.get("degradation_value", "")), to_float(row.get(metric, ""))))
+    for points in grouped.values():
+        points.sort()
+
+    width, height = 860, 460
+    left, right, top, bottom = 86, 28, 34, 76
+    plot_width = width - left - right
+    plot_height = height - top - bottom
+    colors = ["#1f77b4", "#d62728", "#2ca02c", "#9467bd", "#ff7f0e", "#17becf"]
+
+    x_values = [point[0] for points in grouped.values() for point in points]
+    y_values = [point[1] for points in grouped.values() for point in points]
+    x_min, x_max = value_range(x_values)
+    if metric in ("success_rate", "collision_rate"):
+        y_min, y_max = 0.0, 1.0
+    else:
+        y_min, y_max = value_range(y_values)
+
+    def map_x(value):
+        return left + (value - x_min) / (x_max - x_min) * plot_width
+
+    def map_y(value):
+        return top + (y_max - value) / (y_max - y_min) * plot_height
+
+    title = "{} vs {}".format(ylabel, axis)
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<svg xmlns="http://www.w3.org/2000/svg" width="{}" height="{}" viewBox="0 0 {} {}">'.format(width, height, width, height),
+        '<rect width="100%" height="100%" fill="white"/>',
+        '<text x="{}" y="22" font-family="Arial, sans-serif" font-size="16" font-weight="700">{}</text>'.format(left, html.escape(title)),
+    ]
+    for idx in range(6):
+        ratio = idx / 5.0
+        y_value = y_min + (y_max - y_min) * ratio
+        y = map_y(y_value)
+        lines.append('<line x1="{:.1f}" y1="{:.1f}" x2="{:.1f}" y2="{:.1f}" stroke="#e5e7eb" stroke-width="1"/>'.format(left, y, left + plot_width, y))
+        lines.append('<text x="{}" y="{:.1f}" font-family="Arial, sans-serif" font-size="11" text-anchor="end" fill="#374151">{:.3g}</text>'.format(left - 8, y + 4, y_value))
+    lines.append('<line x1="{0}" y1="{1}" x2="{2}" y2="{1}" stroke="#111827" stroke-width="1.2"/>'.format(left, top + plot_height, left + plot_width))
+    lines.append('<line x1="{0}" y1="{1}" x2="{0}" y2="{2}" stroke="#111827" stroke-width="1.2"/>'.format(left, top, top + plot_height))
+
+    for x_value in sorted(set(x_values)):
+        x = map_x(x_value)
+        lines.append('<line x1="{:.1f}" y1="{}" x2="{:.1f}" y2="{}" stroke="#111827" stroke-width="1"/>'.format(x, top + plot_height, x, top + plot_height + 5))
+        lines.append('<text x="{:.1f}" y="{}" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#374151">{:.3g}</text>'.format(x, top + plot_height + 22, x_value))
+
+    lines.append('<text x="{}" y="{}" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#111827">{}</text>'.format(left + plot_width / 2, height - 20, html.escape(axis)))
+    lines.append('<text x="20" y="{}" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#111827" transform="rotate(-90 20,{})">{}</text>'.format(top + plot_height / 2, top + plot_height / 2, html.escape(ylabel)))
+
+    for idx, (method, points) in enumerate(sorted(grouped.items())):
+        color = colors[idx % len(colors)]
+        coords = ["{:.1f},{:.1f}".format(map_x(x), map_y(y)) for x, y in points]
+        lines.append('<polyline points="{}" fill="none" stroke="{}" stroke-width="2.2"/>'.format(" ".join(coords), color))
+        for x, y in points:
+            lines.append('<circle cx="{:.1f}" cy="{:.1f}" r="3.5" fill="{}"/>'.format(map_x(x), map_y(y), color))
+        legend_y = top + 18 + idx * 18
+        lines.append('<rect x="{}" y="{}" width="12" height="12" fill="{}"/>'.format(left + plot_width - 180, legend_y - 10, color))
+        lines.append('<text x="{}" y="{}" font-family="Arial, sans-serif" font-size="12" fill="#111827">{}</text>'.format(left + plot_width - 162, legend_y, html.escape(method)))
+
+    lines.append("</svg>")
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as svg_file:
+        svg_file.write("\n".join(lines))
+
+
+def markdown_table(headers, rows):
+    lines = []
+    lines.append("| " + " | ".join(headers) + " |")
+    lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
+    for row in rows:
+        values = []
+        for header in headers:
+            value = row.get(header, "")
+            if isinstance(value, float):
+                value = "{:.4g}".format(value)
+            values.append(str(value))
+        lines.append("| " + " | ".join(values) + " |")
+    return "\n".join(lines)
+
+
+def write_markdown(path, overall, robustness):
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    headers = ["method_name", "run_count", "success_rate", "collision_rate", "min_distance_mean", "travel_time_mean"]
+    robust_headers = ["degradation_axis", "degradation_value", "method_name", "run_count", "success_rate", "collision_rate", "min_distance_mean"]
+    with open(path, "w", encoding="utf-8") as md_file:
+        md_file.write("# Stage 6 Tables\n\n")
+        md_file.write("## Clean Overall Method Comparison\n\n")
+        md_file.write(markdown_table(headers, overall))
+        md_file.write("\n\n## Robustness By Axis\n\n")
+        md_file.write(markdown_table(robust_headers, robustness))
+        md_file.write("\n")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate Stage 6 summary tables and robustness curves.")
+    parser.add_argument("--input", required=True, help="Stage 6 run CSV")
+    parser.add_argument("--output-dir", required=True, help="Output directory")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    with open(args.input, newline="", encoding="utf-8") as csv_file:
+        rows = list(csv.DictReader(csv_file))
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    summary = group_rows(rows, SUMMARY_GROUP)
+    overall = group_rows(clean_rows(rows), ["method_name", "planner_mode"])
+    by_scenario = group_rows(clean_rows(rows), ["scenario_name", "method_name", "planner_mode"])
+    robust = robustness_rows(rows)
+
+    write_csv(os.path.join(args.output_dir, "stage6_summary.csv"), SUMMARY_GROUP + METRICS, summary)
+    write_csv(os.path.join(args.output_dir, "stage6_method_comparison_overall.csv"), ["method_name", "planner_mode"] + METRICS, overall)
+    write_csv(os.path.join(args.output_dir, "stage6_method_comparison_by_scenario.csv"), ["scenario_name", "method_name", "planner_mode"] + METRICS, by_scenario)
+    write_csv(os.path.join(args.output_dir, "stage6_robustness.csv"), ["degradation_axis", "degradation_value", "method_name", "planner_mode"] + METRICS, robust)
+    write_markdown(os.path.join(args.output_dir, "stage6_tables.md"), overall, robust)
+
+    plot_dir = os.path.join(args.output_dir, "plots")
+    axes = sorted({row.get("degradation_axis", "") for row in robust if row.get("degradation_axis", "")})
+    plots = [
+        ("success_rate", "Success Rate"),
+        ("collision_rate", "Collision Rate"),
+        ("min_distance_mean", "Mean Min Distance (m)"),
+    ]
+    for axis in axes:
+        for metric, ylabel in plots:
+            write_svg_curve(robust, axis, metric, ylabel, os.path.join(plot_dir, "{}_{}.svg".format(axis, metric)))
+
+    print("Wrote Stage 6 analysis to {}".format(args.output_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/experiment_tools/scripts/experiment_metric_recorder.py
+++ b/experiment_tools/scripts/experiment_metric_recorder.py
@@ -65,6 +65,11 @@ class ExperimentMetricRecorder:
         configured_run_id = rospy.get_param("~run_id", "")
         self.run_id = configured_run_id or self.make_run_id()
         self.notes = rospy.get_param("~notes", "")
+        self.world_name = rospy.get_param("~world_name", "")
+        self.planner_mode = rospy.get_param("~planner_mode", "")
+        self.fixed_safety_margin = as_float(rospy.get_param("~fixed_safety_margin", 0.0))
+        self.degradation_axis = rospy.get_param("~degradation_axis", "clean")
+        self.degradation_value = rospy.get_param("~degradation_value", "0")
 
         self.position_noise_std = as_float(rospy.get_param("~position_noise_std", 0.0))
         self.velocity_noise_std = as_float(rospy.get_param("~velocity_noise_std", 0.0))
@@ -307,6 +312,11 @@ class ExperimentMetricRecorder:
             "ros_time_end",
             "scenario_name",
             "method_name",
+            "world_name",
+            "planner_mode",
+            "fixed_safety_margin",
+            "degradation_axis",
+            "degradation_value",
             "position_noise_std",
             "velocity_noise_std",
             "delay_ms",
@@ -375,6 +385,11 @@ class ExperimentMetricRecorder:
             "ros_time_end": self.end_ros_time if self.end_ros_time is not None else "",
             "scenario_name": self.scenario_name,
             "method_name": self.method_name,
+            "world_name": self.world_name,
+            "planner_mode": self.planner_mode,
+            "fixed_safety_margin": self.fixed_safety_margin,
+            "degradation_axis": self.degradation_axis,
+            "degradation_value": self.degradation_value,
             "position_noise_std": self.position_noise_std,
             "velocity_noise_std": self.velocity_noise_std,
             "delay_ms": self.delay_ms,

--- a/experiment_tools/scripts/generate_stage6_manifest.py
+++ b/experiment_tools/scripts/generate_stage6_manifest.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import os
+import re
+import sys
+
+try:
+    import yaml
+except ImportError as exc:
+    raise SystemExit("PyYAML is required to read the Stage 6 matrix config.") from exc
+
+
+FIELDNAMES = [
+    "run_id",
+    "scenario_name",
+    "world_name",
+    "method_name",
+    "planner_mode",
+    "fixed_safety_margin",
+    "enable_uncertainty_pipeline",
+    "degradation_axis",
+    "degradation_value",
+    "position_noise_std",
+    "velocity_noise_std",
+    "delay_ms",
+    "dropout_prob",
+    "false_positive_prob",
+    "confidence_noise",
+    "random_seed",
+    "run_duration_sec",
+    "sim_pkg",
+    "sim_launch",
+    "planner_pkg",
+    "planner_launch",
+    "recorder_pkg",
+    "recorder_launch",
+]
+
+
+def slug(value):
+    text = str(value).strip().lower()
+    text = text.replace(".", "p")
+    text = re.sub(r"[^a-z0-9_]+", "_", text)
+    return text.strip("_") or "0"
+
+
+def as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def load_config(path):
+    with open(path, "r", encoding="utf-8") as yaml_file:
+        config = yaml.safe_load(yaml_file) or {}
+    for key in ("methods", "scenarios", "seeds", "degradation_defaults", "degradation_sweeps"):
+        if key not in config:
+            raise ValueError("Missing required config key: {}".format(key))
+    return config
+
+
+def build_conditions(config):
+    defaults = dict(config["degradation_defaults"])
+    conditions = []
+    clean = dict(defaults)
+    clean["degradation_axis"] = "clean"
+    clean["degradation_value"] = "0"
+    conditions.append(clean)
+
+    include_axis_zero = bool(config.get("include_axis_zero", False))
+    for sweep in config["degradation_sweeps"]:
+        axis = sweep["axis"]
+        if axis not in defaults:
+            raise ValueError("Sweep axis '{}' is not present in degradation_defaults.".format(axis))
+        for value in as_list(sweep.get("values")):
+            if not include_axis_zero and float(value) == float(defaults.get(axis, 0.0)):
+                continue
+            condition = dict(defaults)
+            condition[axis] = value
+            condition["degradation_axis"] = axis
+            condition["degradation_value"] = str(value)
+            conditions.append(condition)
+    return conditions
+
+
+def enabled_methods(config, include_disabled):
+    methods = []
+    skipped = []
+    for method in config["methods"]:
+        if method.get("enabled", True) or include_disabled:
+            methods.append(method)
+        else:
+            skipped.append(method.get("name", "unknown"))
+    return methods, skipped
+
+
+def generate_rows(config, include_disabled=False, limit=0):
+    methods, skipped = enabled_methods(config, include_disabled)
+    conditions = build_conditions(config)
+    seeds = as_list(config["seeds"])
+    launch = config.get("launch", {})
+    run_duration = config.get("run_duration_sec", 60)
+
+    rows = []
+    for scenario in config["scenarios"]:
+        for method in methods:
+            for condition in conditions:
+                for seed in seeds:
+                    run_id = "{}_{}_{}_{}_seed{}".format(
+                        slug(scenario["name"]),
+                        slug(method["name"]),
+                        slug(condition["degradation_axis"]),
+                        slug(condition["degradation_value"]),
+                        slug(seed),
+                    )
+                    row = {
+                        "run_id": run_id,
+                        "scenario_name": scenario["name"],
+                        "world_name": scenario["world_name"],
+                        "method_name": method["name"],
+                        "planner_mode": method.get("planner_mode", "original"),
+                        "fixed_safety_margin": method.get("fixed_safety_margin", 0.0),
+                        "enable_uncertainty_pipeline": str(bool(method.get("enable_uncertainty_pipeline", False))).lower(),
+                        "degradation_axis": condition["degradation_axis"],
+                        "degradation_value": condition["degradation_value"],
+                        "position_noise_std": condition.get("position_noise_std", 0.0),
+                        "velocity_noise_std": condition.get("velocity_noise_std", 0.0),
+                        "delay_ms": condition.get("delay_ms", 0.0),
+                        "dropout_prob": condition.get("dropout_prob", 0.0),
+                        "false_positive_prob": condition.get("false_positive_prob", 0.0),
+                        "confidence_noise": condition.get("confidence_noise", 0.0),
+                        "random_seed": seed,
+                        "run_duration_sec": run_duration,
+                        "sim_pkg": launch.get("sim_pkg", "uav_simulator"),
+                        "sim_launch": launch.get("sim_launch", "start_stage6.launch"),
+                        "planner_pkg": launch.get("planner_pkg", "autonomous_flight"),
+                        "planner_launch": launch.get("planner_launch", "intent_mpc_demo_stage6.launch"),
+                        "recorder_pkg": launch.get("recorder_pkg", "experiment_tools"),
+                        "recorder_launch": launch.get("recorder_launch", "record_stage6.launch"),
+                    }
+                    rows.append(row)
+                    if limit and len(rows) >= limit:
+                        return rows, skipped
+    return rows, skipped
+
+
+def write_csv(path, rows):
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: row.get(key, "") for key in FIELDNAMES})
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate the Stage 6 experiment manifest.")
+    parser.add_argument("--config", required=True, help="Stage 6 matrix YAML config")
+    parser.add_argument("--output", required=True, help="Output manifest CSV")
+    parser.add_argument("--include-disabled", action="store_true", help="Include disabled methods such as future NavRL placeholders")
+    parser.add_argument("--limit", type=int, default=0, help="Optional row limit for pilot manifests")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    config = load_config(args.config)
+    rows, skipped = generate_rows(config, include_disabled=args.include_disabled, limit=max(args.limit, 0))
+    write_csv(args.output, rows)
+    print("Wrote {} Stage 6 manifest rows to {}".format(len(rows), args.output))
+    if skipped:
+        print("Skipped disabled methods: {}".format(", ".join(skipped)), file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiment_tools/scripts/run_stage6_batch.py
+++ b/experiment_tools/scripts/run_stage6_batch.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+import argparse
+import csv
+import os
+import shlex
+import signal
+import subprocess
+import time
+
+
+def truthy(value):
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
+def source_prefix(workspace):
+    repo = os.path.join(workspace, "src", "Intent-MPC")
+    return "source /opt/ros/noetic/setup.bash && source {} && source {}".format(
+        shlex.quote(os.path.join(workspace, "devel", "setup.bash")),
+        shlex.quote(os.path.join(repo, "uav_simulator", "gazeboSetup.bash")),
+    )
+
+
+def roslaunch_command(pkg, launch_file, args):
+    parts = ["roslaunch", pkg, launch_file]
+    for key, value in args.items():
+        if value is None or value == "":
+            continue
+        parts.append("{}:={}".format(key, value))
+    return " ".join(shlex.quote(str(part)) for part in parts)
+
+
+def bash_command(prefix, command):
+    return "{} && {}".format(prefix, command)
+
+
+def popen(prefix, command, log_path=None):
+    stdout = subprocess.DEVNULL
+    log_file = None
+    if log_path:
+        os.makedirs(os.path.dirname(os.path.abspath(log_path)), exist_ok=True)
+        log_file = open(log_path, "a", encoding="utf-8")
+        stdout = log_file
+    proc = subprocess.Popen(
+        ["bash", "-lc", bash_command(prefix, command)],
+        stdout=stdout,
+        stderr=subprocess.STDOUT,
+        preexec_fn=os.setsid,
+    )
+    proc._stage6_log_file = log_file
+    return proc
+
+
+def terminate(proc, timeout=8.0):
+    if proc is None:
+        return
+    if proc.poll() is not None:
+        if getattr(proc, "_stage6_log_file", None):
+            proc._stage6_log_file.close()
+        return
+    try:
+        os.killpg(proc.pid, signal.SIGINT)
+        proc.wait(timeout=timeout)
+    except Exception:
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+            proc.wait(timeout=timeout)
+        except Exception:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except Exception:
+                pass
+    if getattr(proc, "_stage6_log_file", None):
+        proc._stage6_log_file.close()
+
+
+def run_shell(prefix, command, timeout=None):
+    return subprocess.run(
+        ["bash", "-lc", bash_command(prefix, command)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def wait_for_odom(prefix, timeout_sec):
+    deadline = time.time() + timeout_sec
+    topics = ["/CERLAB/quadcopter/odom", "/CERLAB/quadcopter/odom_raw"]
+    while time.time() < deadline:
+        for topic in topics:
+            result = run_shell(prefix, "timeout 3s rostopic echo -n 1 {} >/dev/null 2>&1".format(shlex.quote(topic)))
+            if result.returncode == 0:
+                return True
+        time.sleep(1.0)
+    return False
+
+
+def cleanup_ros(prefix):
+    commands = [
+        "rosnode kill -a >/dev/null 2>&1 || true",
+        "pkill -x rviz >/dev/null 2>&1 || true",
+        "pkill -x gzclient >/dev/null 2>&1 || true",
+        "pkill -x gzserver >/dev/null 2>&1 || true",
+        "pkill -x rosmaster >/dev/null 2>&1 || true",
+        "pkill -x roscore >/dev/null 2>&1 || true",
+    ]
+    run_shell(prefix, " ; ".join(commands), timeout=15)
+
+
+def read_manifest(path):
+    with open(path, newline="", encoding="utf-8") as csv_file:
+        return list(csv.DictReader(csv_file))
+
+
+def select_rows(rows, start_index, limit):
+    selected = rows[max(start_index, 0):]
+    if limit:
+        selected = selected[:limit]
+    return selected
+
+
+def row_commands(row, output_dir, gui, rviz):
+    sim_args = {
+        "world_name": row["world_name"],
+        "gui": str(gui).lower(),
+        "keyboard": "false",
+    }
+    planner_args = {
+        "dynamic_obstacle_mode": row["planner_mode"],
+        "fixed_safety_margin": row["fixed_safety_margin"],
+        "enable_uncertainty_pipeline": row["enable_uncertainty_pipeline"],
+        "rviz": str(rviz).lower(),
+        "position_noise_std": row["position_noise_std"],
+        "velocity_noise_std": row["velocity_noise_std"],
+        "delay_ms": row["delay_ms"],
+        "dropout_prob": row["dropout_prob"],
+        "false_positive_prob": row["false_positive_prob"],
+        "confidence_noise": row["confidence_noise"],
+        "random_seed": row["random_seed"],
+        "output_dir": output_dir,
+    }
+    recorder_args = {
+        "scenario_name": row["scenario_name"],
+        "method_name": row["method_name"],
+        "run_id": row["run_id"],
+        "world_name": row["world_name"],
+        "planner_mode": row["planner_mode"],
+        "fixed_safety_margin": row["fixed_safety_margin"],
+        "degradation_axis": row["degradation_axis"],
+        "degradation_value": row["degradation_value"],
+        "position_noise_std": row["position_noise_std"],
+        "velocity_noise_std": row["velocity_noise_std"],
+        "delay_ms": row["delay_ms"],
+        "dropout_prob": row["dropout_prob"],
+        "false_positive_prob": row["false_positive_prob"],
+        "confidence_noise": row["confidence_noise"],
+        "random_seed": row["random_seed"],
+        "output_dir": output_dir,
+        "output_csv": "stage6_runs.csv",
+        "sample_csv": "stage6_samples.csv",
+    }
+    return (
+        roslaunch_command(row["sim_pkg"], row["sim_launch"], sim_args),
+        roslaunch_command(row["planner_pkg"], row["planner_launch"], planner_args),
+        roslaunch_command(row["recorder_pkg"], row["recorder_launch"], recorder_args),
+    )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run or print Stage 6 experiment batches from a manifest CSV.")
+    parser.add_argument("--manifest", required=True, help="Stage 6 manifest CSV")
+    parser.add_argument("--workspace", default=os.path.expanduser("~/catkin_ws"), help="Catkin workspace path")
+    parser.add_argument("--output-dir", default=os.path.expanduser("~/catkin_ws/experiment_logs/stage6"), help="Run output directory")
+    parser.add_argument("--start-index", type=int, default=0, help="First manifest row index to run")
+    parser.add_argument("--limit", type=int, default=0, help="Maximum rows to run")
+    parser.add_argument("--run-duration-sec", type=float, default=0.0, help="Override manifest run duration")
+    parser.add_argument("--odom-timeout-sec", type=float, default=60.0, help="Wait time for simulator odometry")
+    parser.add_argument("--gui", action="store_true", help="Show Gazebo GUI")
+    parser.add_argument("--rviz", action="store_true", help="Show RViz")
+    parser.add_argument("--execute", action="store_true", help="Actually run experiments. Without this flag, commands are printed only.")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    rows = select_rows(read_manifest(args.manifest), args.start_index, args.limit)
+    prefix = source_prefix(os.path.abspath(os.path.expanduser(args.workspace)))
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    if not args.execute:
+        for idx, row in enumerate(rows, start=args.start_index):
+            sim_cmd, planner_cmd, recorder_cmd = row_commands(row, args.output_dir, args.gui, args.rviz)
+            print("# row {} run_id={}".format(idx, row["run_id"]))
+            print(bash_command(prefix, sim_cmd))
+            print(bash_command(prefix, planner_cmd))
+            print(bash_command(prefix, recorder_cmd))
+        print("Dry run only. Re-run with --execute to launch experiments.")
+        return
+
+    for idx, row in enumerate(rows, start=args.start_index):
+        run_id = row["run_id"]
+        duration = args.run_duration_sec or float(row.get("run_duration_sec") or 60.0)
+        log_dir = os.path.join(args.output_dir, "logs", run_id)
+        sim_cmd, planner_cmd, recorder_cmd = row_commands(row, args.output_dir, args.gui, args.rviz)
+        print("[stage6] row {} run_id={} duration={}s".format(idx, run_id, duration), flush=True)
+
+        sim_proc = planner_proc = recorder_proc = None
+        try:
+            sim_proc = popen(prefix, sim_cmd, os.path.join(log_dir, "sim.log"))
+            if not wait_for_odom(prefix, args.odom_timeout_sec):
+                raise RuntimeError("Timed out waiting for /CERLAB/quadcopter/odom")
+            planner_proc = popen(prefix, planner_cmd, os.path.join(log_dir, "planner.log"))
+            time.sleep(8.0)
+            recorder_proc = popen(prefix, recorder_cmd, os.path.join(log_dir, "recorder.log"))
+            time.sleep(duration)
+        finally:
+            terminate(recorder_proc)
+            terminate(planner_proc)
+            terminate(sim_proc)
+            cleanup_ros(prefix)
+            time.sleep(2.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/uav_simulator/launch/start_stage6.launch
+++ b/uav_simulator/launch/start_stage6.launch
@@ -1,0 +1,45 @@
+<launch>
+  <arg name="paused" default="false" />
+  <arg name="verbose" default="false" />
+  <arg name="use_sim_time" default="true" />
+  <arg name="debug" default="false" />
+  <arg name="gui" default="false" />
+  <arg name="lidar" default="false" />
+  <arg name="keyboard" default="false" />
+  <arg name="world_name" default="$(find uav_simulator)/worlds/generated_env/generated_env.world" />
+  <arg name="spawn_x" default="0.0" />
+  <arg name="spawn_y" default="7.0" />
+  <arg name="spawn_z" default="0.1" />
+  <arg name="spawn_yaw" default="-3.14" />
+
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="paused" value="$(arg paused)" />
+    <arg name="world_name" value="$(arg world_name)" />
+    <arg name="verbose" value="$(arg verbose)" />
+    <arg name="use_sim_time" value="$(arg use_sim_time)" />
+    <arg name="debug" value="$(arg debug)" />
+    <arg name="gui" value="$(arg gui)" />
+  </include>
+
+  <group if="$(arg lidar)">
+    <param name="robot_description" command="cat '$(find uav_simulator)/urdf/quadcopter_lidar.urdf'" />
+  </group>
+
+  <group unless="$(arg lidar)">
+    <param name="robot_description" command="cat '$(find uav_simulator)/urdf/quadcopter.urdf'" />
+  </group>
+
+  <node pkg="topic_tools" type="throttle" name="gt_pose_throttle" args="messages /CERLAB/quadcopter/pose_raw 30 /CERLAB/quadcopter/pose" />
+  <node pkg="topic_tools" type="throttle" name="gt_vel_throttle" args="messages /CERLAB/quadcopter/vel_raw 30 /CERLAB/quadcopter/vel" />
+  <node pkg="topic_tools" type="throttle" name="gt_acc_throttle" args="messages /CERLAB/quadcopter/acc_raw 30 /CERLAB/quadcopter/acc" />
+  <node pkg="topic_tools" type="throttle" name="gt_odom_throttle" args="messages /CERLAB/quadcopter/odom_raw 30 /CERLAB/quadcopter/odom" />
+  <node name="spawn_gazebo_model" pkg="gazebo_ros" type="spawn_model" args="-urdf -param robot_description -model quadcopter -x $(arg spawn_x) -y $(arg spawn_y) -z $(arg spawn_z) -Y $(arg spawn_yaw)" respawn="false" />
+
+  <include file="$(find uav_simulator)/launch/setupTF.launch">
+    <arg name="pose_topic" value="/CERLAB/quadcopter/pose" />
+  </include>
+
+  <group if="$(arg keyboard)">
+    <node name="keyboard_control" pkg="uav_simulator" type="keyboard_control" />
+  </group>
+</launch>


### PR DESCRIPTION
## Summary
- Add Stage 6 paper experiment matrix config for Intent-MPC, fixed-margin, and uncertainty-aware Intent-MPC.
- Add disabled placeholders for future NavRL and NavRL + safety shield comparisons.
- Add headless simulator launch, Stage 6 planner launch, and Stage 6 recorder launch.
- Extend run CSV metadata with world, planner mode, fixed margin, and degradation axis/value.
- Add manifest generation, batch execution, and analysis scripts for summary tables and SVG robustness curves.

## Validation
- Python syntax check passed for recorder, manifest, batch, analysis, summary, and plot scripts.
- Manifest generation produced 585 executable rows from the default matrix.
- Batch dry-run printed simulator/planner/recorder commands.
- Synthetic CSV analysis generated summary CSV, method comparison tables, robustness CSV, Markdown table, and SVG curves.
- `catkin_make` passed in Docker ROS Noetic.
- `roslaunch --nodes` passed for `start_stage6.launch`, `intent_mpc_demo_stage6.launch`, uncertainty-aware Stage 6 launch, and `record_stage6.launch`.
- One 8-second headless pilot run executed and wrote `stage6_runs.csv` plus `stage6_samples.csv`.

## Boundary
The full 585-run matrix was not executed in this branch. NavRL entries remain disabled until a real launch integration exists. Original/fixed-margin modes still use the original detector/predictor path, while uncertainty-aware mode consumes Stage 3/4 uncertainty.

Closes #15
Closes #16
